### PR TITLE
AI UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ routes.js
 todo.txt
 /replays.db
 /test.json
+out

--- a/package-lock.json
+++ b/package-lock.json
@@ -5348,6 +5348,27 @@
             "strip-ansi": "^6.0.0"
           }
         },
+        "@vue/vue-loader-v15": {
+          "version": "npm:vue-loader@15.10.1",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
+          "integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
+          "dev": true,
+          "requires": {
+            "@vue/component-compiler-utils": "^3.1.0",
+            "hash-sum": "^1.0.2",
+            "loader-utils": "^1.1.0",
+            "vue-hot-reload-api": "^2.3.0",
+            "vue-style-loader": "^4.1.0"
+          },
+          "dependencies": {
+            "hash-sum": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
+              "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
+              "dev": true
+            }
+          }
+        },
         "acorn-walk": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
@@ -6232,27 +6253,6 @@
       "resolved": "http://verdaccio.slot.works:4873/@vue%2fshared/-/shared-3.2.20.tgz",
       "integrity": "sha512-FbpX+hD5BvXCQerEYO7jtAGHlhAkhTQ4KIV73kmLWNlawWhTiVuQxizgVb0BOkX5oG9cIRZ42EG++d/k/Efp0w==",
       "dev": true
-    },
-    "@vue/vue-loader-v15": {
-      "version": "npm:vue-loader@15.10.0",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.0.tgz",
-      "integrity": "sha512-VU6tuO8eKajrFeBzMssFUP9SvakEeeSi1BxdTH5o3+1yUyrldp8IERkSdXlMI2t4kxF2sqYUDsQY+WJBxzBmZg==",
-      "dev": true,
-      "requires": {
-        "@vue/component-compiler-utils": "^3.1.0",
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.1.0",
-        "vue-hot-reload-api": "^2.3.0",
-        "vue-style-loader": "^4.1.0"
-      },
-      "dependencies": {
-        "hash-sum": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-          "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
-          "dev": true
-        }
-      }
     },
     "@vue/web-component-wrapper": {
       "version": "1.3.0",
@@ -13352,18 +13352,18 @@
       "requires": {
         "fastify-autoload-deprecated": "npm:fastify-autoload@3.12.0",
         "process-warning": "^1.0.0"
-      }
-    },
-    "fastify-autoload-deprecated": {
-      "version": "npm:fastify-autoload@3.12.0",
-      "resolved": "https://registry.npmjs.org/fastify-autoload/-/fastify-autoload-3.12.0.tgz",
-      "integrity": "sha512-qm8HG8V24A0AdcIjGMMTnyKQj6yzEbdcXHbWjzPtYPReGo4D4Ki7oRLDocYQJVpaOxlcLJSbadfMhZTu3+G6oQ==",
-      "dev": true,
-      "requires": {
-        "pkg-up": "^3.1.0",
-        "semver": "^7.3.5"
       },
       "dependencies": {
+        "fastify-autoload-deprecated": {
+          "version": "npm:fastify-autoload@3.12.0",
+          "resolved": "https://registry.npmjs.org/fastify-autoload/-/fastify-autoload-3.12.0.tgz",
+          "integrity": "sha512-qm8HG8V24A0AdcIjGMMTnyKQj6yzEbdcXHbWjzPtYPReGo4D4Ki7oRLDocYQJVpaOxlcLJSbadfMhZTu3+G6oQ==",
+          "dev": true,
+          "requires": {
+            "pkg-up": "^3.1.0",
+            "semver": "^7.3.5"
+          }
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -13383,16 +13383,18 @@
       "requires": {
         "fastify-cors-deprecated": "npm:fastify-cors@6.0.3",
         "process-warning": "^1.0.0"
-      }
-    },
-    "fastify-cors-deprecated": {
-      "version": "npm:fastify-cors@6.0.3",
-      "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-6.0.3.tgz",
-      "integrity": "sha512-fMbXubKKyBHHCfSBtsCi3+7VyVRdhJQmGes5gM+eGKkRErCdm0NaYO0ozd31BQBL1ycoTIjbqOZhJo4RTF/Vlg==",
-      "dev": true,
-      "requires": {
-        "fastify-plugin": "^3.0.0",
-        "vary": "^1.1.2"
+      },
+      "dependencies": {
+        "fastify-cors-deprecated": {
+          "version": "npm:fastify-cors@6.0.3",
+          "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-6.0.3.tgz",
+          "integrity": "sha512-fMbXubKKyBHHCfSBtsCi3+7VyVRdhJQmGes5gM+eGKkRErCdm0NaYO0ozd31BQBL1ycoTIjbqOZhJo4RTF/Vlg==",
+          "dev": true,
+          "requires": {
+            "fastify-plugin": "^3.0.0",
+            "vary": "^1.1.2"
+          }
+        }
       }
     },
     "fastify-plugin": {
@@ -13409,19 +13411,19 @@
       "requires": {
         "fastify-rate-limit-deprecated": "npm:fastify-rate-limit@5.8.0",
         "process-warning": "^1.0.0"
-      }
-    },
-    "fastify-rate-limit-deprecated": {
-      "version": "npm:fastify-rate-limit@5.8.0",
-      "resolved": "https://registry.npmjs.org/fastify-rate-limit/-/fastify-rate-limit-5.8.0.tgz",
-      "integrity": "sha512-sln2ZbEG1cb0Ok4pn+tXrZIU0zJUWEimANWB/Bq+z/Ad5fBys9YsmCySrPqhUdBcZHwk9ymX22wbgZvvNLokyQ==",
-      "dev": true,
-      "requires": {
-        "fastify-plugin": "^3.0.1",
-        "ms": "^2.1.3",
-        "tiny-lru": "^8.0.1"
       },
       "dependencies": {
+        "fastify-rate-limit-deprecated": {
+          "version": "npm:fastify-rate-limit@5.8.0",
+          "resolved": "https://registry.npmjs.org/fastify-rate-limit/-/fastify-rate-limit-5.8.0.tgz",
+          "integrity": "sha512-sln2ZbEG1cb0Ok4pn+tXrZIU0zJUWEimANWB/Bq+z/Ad5fBys9YsmCySrPqhUdBcZHwk9ymX22wbgZvvNLokyQ==",
+          "dev": true,
+          "requires": {
+            "fastify-plugin": "^3.0.1",
+            "ms": "^2.1.3",
+            "tiny-lru": "^8.0.1"
+          }
+        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13438,22 +13440,22 @@
       "requires": {
         "fastify-sensible-deprecated": "npm:fastify-sensible@3.1.2",
         "process-warning": "^1.0.0"
-      }
-    },
-    "fastify-sensible-deprecated": {
-      "version": "npm:fastify-sensible@3.1.2",
-      "resolved": "https://registry.npmjs.org/fastify-sensible/-/fastify-sensible-3.1.2.tgz",
-      "integrity": "sha512-fS8GeY6db3q38GzWOoZMggrw9yHOoXdHv1Pgnorvv18uDrmh1iL8gP9/cqdWzZRM1J3fYvcHsfV2t4BXQF2+sw==",
-      "dev": true,
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fastify-plugin": "^3.0.0",
-        "forwarded": "^0.2.0",
-        "http-errors": "^1.7.3",
-        "type-is": "^1.6.18",
-        "vary": "^1.1.2"
       },
       "dependencies": {
+        "fastify-sensible-deprecated": {
+          "version": "npm:fastify-sensible@3.1.2",
+          "resolved": "https://registry.npmjs.org/fastify-sensible/-/fastify-sensible-3.1.2.tgz",
+          "integrity": "sha512-fS8GeY6db3q38GzWOoZMggrw9yHOoXdHv1Pgnorvv18uDrmh1iL8gP9/cqdWzZRM1J3fYvcHsfV2t4BXQF2+sw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fastify-plugin": "^3.0.0",
+            "forwarded": "^0.2.0",
+            "http-errors": "^1.7.3",
+            "type-is": "^1.6.18",
+            "vary": "^1.1.2"
+          }
+        },
         "http-errors": {
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -13489,23 +13491,23 @@
       "requires": {
         "fastify-static-deprecated": "npm:fastify-static@4.6.1",
         "process-warning": "^1.0.0"
-      }
-    },
-    "fastify-static-deprecated": {
-      "version": "npm:fastify-static@4.6.1",
-      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-4.6.1.tgz",
-      "integrity": "sha512-vy7N28U4AMhuOim12ZZWHulEE6OQKtzZbHgiB8Zj4llUuUQXPka0WHAQI3njm1jTCx4W6fixUHfpITxweMtAIA==",
-      "dev": true,
-      "requires": {
-        "content-disposition": "^0.5.3",
-        "encoding-negotiator": "^2.0.1",
-        "fastify-plugin": "^3.0.0",
-        "glob": "^7.1.4",
-        "p-limit": "^3.1.0",
-        "readable-stream": "^3.4.0",
-        "send": "^0.17.1"
       },
       "dependencies": {
+        "fastify-static-deprecated": {
+          "version": "npm:fastify-static@4.6.1",
+          "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-4.6.1.tgz",
+          "integrity": "sha512-vy7N28U4AMhuOim12ZZWHulEE6OQKtzZbHgiB8Zj4llUuUQXPka0WHAQI3njm1jTCx4W6fixUHfpITxweMtAIA==",
+          "dev": true,
+          "requires": {
+            "content-disposition": "^0.5.3",
+            "encoding-negotiator": "^2.0.1",
+            "fastify-plugin": "^3.0.0",
+            "glob": "^7.1.4",
+            "p-limit": "^3.1.0",
+            "readable-stream": "^3.4.0",
+            "send": "^0.17.1"
+          }
+        },
         "p-limit": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,11 @@
 module.exports = {
     ...require("./node_modules/jaz-ts-utils/prettier.config"),
+    overrides: [
+        {
+            "files": "src/**/*.vue",
+            "options": {
+                "printWidth": 140
+            }
+        }
+    ]
 };

--- a/src/api/content/ai-content.ts
+++ b/src/api/content/ai-content.ts
@@ -43,7 +43,7 @@ export class AiContentAPI extends AbstractContentAPI {
     }
 
     public getEngineAI(name: string, engine: string): EngineAI | undefined {
-        return this.installedAis[engine].find((ai) => ai.shortName === name);
+        return this.installedAis[engine]?.find((ai) => ai.shortName === name);
     }
 
     protected async fetchAi(aiDirPath: string): Promise<EngineAI> {

--- a/src/api/content/ai-content.ts
+++ b/src/api/content/ai-content.ts
@@ -1,14 +1,14 @@
 import * as fs from "fs";
 import * as glob from "glob-promise";
+import { clone } from "jaz-ts-utils";
 import * as path from "path";
 import { reactive } from "vue";
 
 import { AbstractContentAPI } from "@/api/content/abstract-content";
 import type { EngineAI } from "@/model/ai";
+import { gameAis } from "@/model/ai";
 import { parseLuaOptions } from "@/utils/parse-lua-options";
 import { parseLuaTable } from "@/utils/parse-lua-table";
-import { gameAis } from "@/model/ai";
-import { clone } from "jaz-ts-utils";
 
 export class AiContentAPI extends AbstractContentAPI {
     protected readonly installedAis: Record<string, EngineAI[]> = reactive({});

--- a/src/api/content/ai-content.ts
+++ b/src/api/content/ai-content.ts
@@ -42,10 +42,6 @@ export class AiContentAPI extends AbstractContentAPI {
         return [...engineAI, ...gameAis];
     }
 
-    public isEngineAI(name: string, engine: string): boolean {
-        return this.getEngineAI(name, engine) !== undefined;
-    }
-
     public getEngineAI(name: string, engine: string): EngineAI | undefined {
         return this.installedAis[engine].find((ai) => ai.shortName === name);
     }

--- a/src/assets/styles/_tooltip.scss
+++ b/src/assets/styles/_tooltip.scss
@@ -2,6 +2,7 @@ $color: #222;
 
 .p-tooltip {
     z-index: 10;
+    max-width: 400px;
     &-text {
         background: $color;
         padding: 2px 7px;

--- a/src/components/battle/AddBotModal.vue
+++ b/src/components/battle/AddBotModal.vue
@@ -1,7 +1,13 @@
 <template>
     <Modal title="Add Bot">
         <div class="gap-md container">
-            <Button class="ai-button" v-tooltip.bottom="{ value: getAiDescription(ai) }" v-for="(ai, i) in ais" :key="i" @click="addBot(ai)">
+            <Button
+                v-for="(ai, i) in ais"
+                :key="i"
+                v-tooltip.bottom="{ value: getAiDescription(ai) }"
+                class="ai-button"
+                @click="addBot(ai)"
+            >
                 {{ getAiFriendlyName(ai) }}
             </Button>
         </div>

--- a/src/components/battle/AddBotModal.vue
+++ b/src/components/battle/AddBotModal.vue
@@ -1,13 +1,7 @@
 <template>
     <Modal title="Add Bot">
         <div class="gap-md container">
-            <Button class="ai-button"
-                    v-tooltip.bottom="{value: getAiDescription(ai)}"
-                    v-for="(ai, i) in ais"
-                    :key="i"
-                    @click="addBot(ai)"
-
-            >
+            <Button class="ai-button" v-tooltip.bottom="{ value: getAiDescription(ai) }" v-for="(ai, i) in ais" :key="i" @click="addBot(ai)">
                 {{ getAiFriendlyName(ai) }}
             </Button>
         </div>

--- a/src/components/battle/AddBotModal.vue
+++ b/src/components/battle/AddBotModal.vue
@@ -1,8 +1,14 @@
 <template>
     <Modal title="Add Bot">
-        <div class="gap-md">
-            <Button v-for="(ai, i) in ais" :key="i" @click="addBot(ai)">
-                {{ ai.name }}
+        <div class="gap-md container">
+            <Button class="ai-button"
+                    v-tooltip.bottom="{value: getAiDescription(ai)}"
+                    v-for="(ai, i) in ais"
+                    :key="i"
+                    @click="addBot(ai)"
+
+            >
+                {{ getAiFriendlyName(ai) }}
             </Button>
         </div>
     </Modal>
@@ -13,21 +19,31 @@ import { computed } from "vue";
 
 import Modal from "@/components/common/Modal.vue";
 import Button from "@/components/controls/Button.vue";
-import { AI } from "@/model/ai";
+import { getAiFriendlyName } from "@/model/ai";
+import { getAiDescription } from "@/model/ai";
 
 const props = defineProps<{
     engineVersion: string;
+    teamId: number;
 }>();
 
+api.content.ai.processAis(props.engineVersion);
 const ais = computed(() => api.content.ai.getAis(props.engineVersion));
 
 const emit = defineEmits<{
-    (event: "add-bot", ai: AI): void;
+    (event: "bot-selected", bot: string, teamId: number): void;
 }>();
 
-const addBot = (ai: AI) => {
-    emit("add-bot", ai);
+const addBot = (bot: string) => {
+    emit("bot-selected", bot, props.teamId);
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.ai-button {
+    padding: 15px;
+}
+.container {
+    width: 500px;
+}
+</style>

--- a/src/components/battle/BattleComponent.vue
+++ b/src/components/battle/BattleComponent.vue
@@ -109,7 +109,13 @@
             />
             <div class="flex-row flex-bottom gap-md">
                 <Button class="red fullwidth" @click="leave"> Leave </Button>
-                <Button v-if="!isOfflineBattle" class="fullwidth" :class="{ gray: !me.battleStatus.ready, green: me.battleStatus.ready }" :disabled="me.battleStatus.isSpectator" @click="toggleReady">
+                <Button
+                    v-if="!isOfflineBattle"
+                    class="fullwidth"
+                    :class="{ gray: !me.battleStatus.ready, green: me.battleStatus.ready }"
+                    :disabled="me.battleStatus.isSpectator"
+                    @click="toggleReady"
+                >
                     Ready
                 </Button>
                 <Button class="green fullwidth" :disabled="isGameRunning" @click="start">

--- a/src/components/battle/BotParticipant.vue
+++ b/src/components/battle/BotParticipant.vue
@@ -23,10 +23,10 @@ import { Ref, ref } from "vue";
 
 import LuaOptionsModal from "@/components/battle/LuaOptionsModal.vue";
 import ContextMenu, { ContextMenuEntry } from "@/components/common/ContextMenu.vue";
+import { getAiFriendlyName } from "@/model/ai";
 import { AbstractBattle } from "@/model/battle/abstract-battle";
 import { Bot } from "@/model/battle/types";
 import { LuaOptionSection } from "@/model/lua-options";
-import { getAiFriendlyName } from "@/model/ai";
 
 const props = defineProps<{
     battle: AbstractBattle;

--- a/src/components/battle/BotParticipant.vue
+++ b/src/components/battle/BotParticipant.vue
@@ -2,7 +2,7 @@
     <ContextMenu :entries="getActions(bot)" :args="[bot]">
         <div class="participant" data-type="participant" @mouseenter.stop="onMouseEnter">
             <Icon :icon="robot" :height="16" />
-            <div class="bot-type">[{{ getAiFriendlyName(props.bot.aiShortName) }}] </div>
+            <div class="bot-type">[{{ getAiFriendlyName(props.bot.aiShortName) }}]</div>
             <div>{{ props.bot.name }}</div>
         </div>
         <LuaOptionsModal
@@ -41,9 +41,9 @@ const kickAi = (bot: Bot) => {
 };
 
 const configureAi = async (bot: Bot) => {
-    const engine = props.battle.battleOptions.engineVersion
+    const engine = props.battle.battleOptions.engineVersion;
     await api.content.ai.processAis(engine);
-    const ai = api.content.ai.getEngineAI(bot.aiShortName, engine)
+    const ai = api.content.ai.getEngineAI(bot.aiShortName, engine);
     if (ai) {
         aiOptions.value = ai.options;
         aiOptionsOpen.value = true;

--- a/src/components/battle/BotParticipant.vue
+++ b/src/components/battle/BotParticipant.vue
@@ -2,9 +2,16 @@
     <ContextMenu :entries="getActions(bot)" :args="[bot]">
         <div class="participant" data-type="participant" @mouseenter.stop="onMouseEnter">
             <Icon :icon="robot" :height="16" />
-            <div>[{{getAiFriendlyName(props.bot.aiShortName)}}] {{  props.bot.name }}</div>
+            <div>[{{ getAiFriendlyName(props.bot.aiShortName) }}] {{ props.bot.name }}</div>
         </div>
-        <LuaOptionsModal :id="`configure-bot-${bot.name}`" v-model="aiOptionsOpen" :luaOptions="bot.aiOptions" title="Configure Bot" :sections="aiOptions" @set-options="setBotOptions" />
+        <LuaOptionsModal
+            :id="`configure-bot-${bot.name}`"
+            v-model="aiOptionsOpen"
+            :luaOptions="bot.aiOptions"
+            title="Configure Bot"
+            :sections="aiOptions"
+            @set-options="setBotOptions"
+        />
     </ContextMenu>
 </template>
 
@@ -33,8 +40,8 @@ const kickAi = (bot: Bot) => {
 };
 
 const configureAi = async (bot: Bot) => {
-    const engine = props.battle.battleOptions.engineVersion
-    const ai = api.content.ai.getEngineAI(bot.aiShortName, engine)
+    const engine = props.battle.battleOptions.engineVersion;
+    const ai = api.content.ai.getEngineAI(bot.aiShortName, engine);
     if (ai) {
         aiOptions.value = ai.options;
         aiOptionsOpen.value = true;
@@ -47,11 +54,11 @@ const setBotOptions = (options: Record<string, unknown>) => {
 
 function getActions(bot: Bot): ContextMenuEntry[] {
     const kickAction = { label: "Kick", action: kickAi };
-    const configureAction = { label: "Configure", action: configureAi }
-    const engine = props.battle.battleOptions.engineVersion
-    const ai = api.content.ai.getEngineAI(bot.aiShortName, engine)
-    if(ai) {
-        return [kickAction, configureAction] as ContextMenuEntry[]
+    const configureAction = { label: "Configure", action: configureAi };
+    const engine = props.battle.battleOptions.engineVersion;
+    const ai = api.content.ai.getEngineAI(bot.aiShortName, engine);
+    if (ai) {
+        return [kickAction, configureAction] as ContextMenuEntry[];
     }
     return [kickAction] as ContextMenuEntry[];
 }

--- a/src/components/battle/BotParticipant.vue
+++ b/src/components/battle/BotParticipant.vue
@@ -2,7 +2,8 @@
     <ContextMenu :entries="getActions(bot)" :args="[bot]">
         <div class="participant" data-type="participant" @mouseenter.stop="onMouseEnter">
             <Icon :icon="robot" :height="16" />
-            <div>[{{ getAiFriendlyName(props.bot.aiShortName) }}] {{ props.bot.name }}</div>
+            <div class="bot-type">[{{ getAiFriendlyName(props.bot.aiShortName) }}] </div>
+            <div>{{ props.bot.name }}</div>
         </div>
         <LuaOptionsModal
             :id="`configure-bot-${bot.name}`"
@@ -85,5 +86,8 @@ const onMouseEnter = () => {
     &:hover {
         background: rgba(255, 255, 255, 0.1);
     }
+}
+.bot-type {
+    opacity: 0.5;
 }
 </style>

--- a/src/components/battle/BotParticipant.vue
+++ b/src/components/battle/BotParticipant.vue
@@ -34,8 +34,7 @@ const kickAi = (bot: Bot) => {
 
 const configureAi = async (bot: Bot) => {
     const engine = props.battle.battleOptions.engineVersion
-    await api.content.ai.processAis(engine);
-
+    //await api.content.ai.processAis(engine);
     const ai = api.content.ai.getEngineAI(bot.aiShortName, engine)
     if (ai) {
         aiOptions.value = ai.options;

--- a/src/components/battle/BotParticipant.vue
+++ b/src/components/battle/BotParticipant.vue
@@ -40,8 +40,9 @@ const kickAi = (bot: Bot) => {
 };
 
 const configureAi = async (bot: Bot) => {
-    const engine = props.battle.battleOptions.engineVersion;
-    const ai = api.content.ai.getEngineAI(bot.aiShortName, engine);
+    const engine = props.battle.battleOptions.engineVersion
+    await api.content.ai.processAis(engine);
+    const ai = api.content.ai.getEngineAI(bot.aiShortName, engine)
     if (ai) {
         aiOptions.value = ai.options;
         aiOptionsOpen.value = true;

--- a/src/components/battle/BotParticipant.vue
+++ b/src/components/battle/BotParticipant.vue
@@ -34,7 +34,6 @@ const kickAi = (bot: Bot) => {
 
 const configureAi = async (bot: Bot) => {
     const engine = props.battle.battleOptions.engineVersion
-    //await api.content.ai.processAis(engine);
     const ai = api.content.ai.getEngineAI(bot.aiShortName, engine)
     if (ai) {
         aiOptions.value = ai.options;

--- a/src/components/battle/BotParticipant.vue
+++ b/src/components/battle/BotParticipant.vue
@@ -55,14 +55,14 @@ const setBotOptions = (options: Record<string, unknown>) => {
 };
 
 function getActions(bot: Bot): ContextMenuEntry[] {
-    const kickAction = { label: "Kick", action: kickAi };
-    const configureAction = { label: "Configure", action: configureAi };
+    const kickAction: ContextMenuEntry = { label: "Kick", action: kickAi };
+    const configureAction: ContextMenuEntry = { label: "Configure", action: configureAi };
     const engine = props.battle.battleOptions.engineVersion;
     const ai = api.content.ai.getEngineAI(bot.aiShortName, engine);
     if (ai) {
-        return [kickAction, configureAction] as ContextMenuEntry[];
+        return [kickAction, configureAction];
     }
-    return [kickAction] as ContextMenuEntry[];
+    return [kickAction];
 }
 
 const onMouseEnter = () => {

--- a/src/components/battle/LuaOptionsModal.vue
+++ b/src/components/battle/LuaOptionsModal.vue
@@ -21,8 +21,16 @@
                                     :step="option.step"
                                     @update:model-value="(value: any) => setOptionValue(option, value)"
                                 />
-                                <Checkbox v-if="option.type === 'boolean'" :modelValue="options[option.key] ?? option.default" @update:model-value="(value) => setOptionValue(option, value)" />
-                                <Textbox v-if="option.type === 'string'" :modelValue="options[option.key] ?? option.default" @update:model-value="(value) => setOptionValue(option, value)" />
+                                <Checkbox
+                                    v-if="option.type === 'boolean'"
+                                    :modelValue="options[option.key] ?? option.default"
+                                    @update:model-value="(value) => setOptionValue(option, value)"
+                                />
+                                <Textbox
+                                    v-if="option.type === 'string'"
+                                    :modelValue="options[option.key] ?? option.default"
+                                    @update:model-value="(value) => setOptionValue(option, value)"
+                                />
                                 <Select
                                     v-if="option.type === 'list'"
                                     :modelValue="options[option.key] ?? option.default"

--- a/src/components/battle/Playerlist.vue
+++ b/src/components/battle/Playerlist.vue
@@ -12,7 +12,8 @@
         >
             <div class="flex-row gap-md">
                 <div class="title">Team {{ teamId + 1 }} ({{ contenders.length }})</div>
-                <Button class="slim" :flexGrow="false" @click="addBot(teamId)"> Add bot </Button>
+                <Button class="slim" @click="openBotList()"> Add bot </Button>
+                <AddBotModal v-model="botListOpen" :engine-version="battle.battleOptions.engineVersion" :team-id="teamId" title="Add Bot" @bot-selected="onBotSelected" />
                 <Button v-if="me.battleStatus.isSpectator || me.battleStatus.teamId !== teamId" class="slim" @click="joinTeam(teamId)"> Join </Button>
             </div>
             <div class="participants">
@@ -32,7 +33,8 @@
         >
             <div class="flex-row gap-md">
                 <div class="title">Team {{ emptyTeamId + 1 }}</div>
-                <Button class="slim" @click="addBot(emptyTeamId)"> Add bot </Button>
+                <Button class="slim" @click="openBotList()"> Add bot </Button>
+                <AddBotModal v-model="botListOpen" :engine-version="battle.battleOptions.engineVersion" :team-id="emptyTeamId" title="Add Bot" @bot-selected="onBotSelected" />
                 <Button class="slim" @click="joinTeam(emptyTeamId)"> Join </Button>
             </div>
         </div>
@@ -68,11 +70,13 @@ import { aiNames } from "@/config/ai-names";
 import { AbstractBattle } from "@/model/battle/abstract-battle";
 import { Bot, Faction } from "@/model/battle/types";
 import { CurrentUser, User } from "@/model/user";
+import AddBotModal from "@/components/battle/AddBotModal.vue";
 
 const props = defineProps<{
     battle: AbstractBattle;
     me: CurrentUser;
 }>();
+const botListOpen = ref(false);
 
 const emptyTeamId = computed(() => {
     const teams = props.battle.teams.value;
@@ -84,7 +88,16 @@ const emptyTeamId = computed(() => {
     return -1;
 });
 
-const addBot = (teamId: number) => {
+const openBotList = () => {
+    botListOpen.value = true;
+}
+
+const onBotSelected = (bot: string, teamId: number) => {
+    botListOpen.value = false;
+    addBot(bot, teamId);
+}
+
+const addBot = (bot: string, teamId: number) => {
     let randomName = randomFromArray(aiNames);
     while (props.battle.bots.some((bot) => bot.name === randomName)) {
         randomName = randomFromArray(aiNames);
@@ -94,7 +107,7 @@ const addBot = (teamId: number) => {
         playerId: props.battle.contenders.value.length,
         teamId,
         name: randomName!,
-        aiShortName: "BARb",
+        aiShortName: bot,
         faction: Faction.Armada,
         ownerUserId: props.me.userId,
         aiOptions: {},

--- a/src/components/battle/Playerlist.vue
+++ b/src/components/battle/Playerlist.vue
@@ -2,13 +2,14 @@
     <div class="playerlist" :class="{ dragging: draggedParticipant !== null }">
         <AddBotModal
             v-model="botListOpen"
-            :engine-version="battle.battleOptions.engineVersion"
-            :team-id="botModalTeamId"
+            :engineVersion="battle.battleOptions.engineVersion"
+            :teamId="botModalTeamId"
             title="Add Bot"
             @bot-selected="onBotSelected" />
         <TeamComponent
-            v-for="[teamId, name] in sortedTeams"
-            :team-id="teamId"
+            v-for="[teamId] in sortedTeams"
+            :key="teamId"
+            :teamId="teamId"
             :battle="battle"
             :me="me"
             @add-bot-clicked="openBotList"
@@ -23,14 +24,14 @@
 
 <script lang="ts" setup>
 import { randomFromArray } from "jaz-ts-utils";
-import { computed, ComputedRef, Ref, ref } from "vue";
+import { computed, Ref, ref } from "vue";
 
+import AddBotModal from "@/components/battle/AddBotModal.vue";
+import TeamComponent from "@/components/battle/TeamComponent.vue";
 import { aiNames } from "@/config/ai-names";
 import { AbstractBattle } from "@/model/battle/abstract-battle";
 import { Bot, Faction } from "@/model/battle/types";
 import { CurrentUser, User } from "@/model/user";
-import AddBotModal from "@/components/battle/AddBotModal.vue";
-import TeamComponent from "@/components/battle/TeamComponent.vue";
 
 const props = defineProps<{
     battle: AbstractBattle;
@@ -45,10 +46,6 @@ const sortedTeams = computed(() => {
     teams.set(-1, props.battle.spectators.value); // Spectators
     return teams;
 });
-
-// This data is improperly cached, I'm unsure of the ideal way to fix it. I force it to refetch
-const engine = props.battle.battleOptions.engineVersion;
-await api.content.ai.processAis(engine);
 
 const openBotList = (teamId: number) => {
     botModalTeamId.value = teamId;

--- a/src/components/battle/Playerlist.vue
+++ b/src/components/battle/Playerlist.vue
@@ -1,12 +1,12 @@
 <template>
+    <AddBotModal
+        v-model="botListOpen"
+        :engineVersion="battle.battleOptions.engineVersion"
+        :teamId="botModalTeamId"
+        title="Add Bot"
+        @bot-selected="onBotSelected"
+    />
     <div class="playerlist" :class="{ dragging: draggedParticipant !== null }">
-        <AddBotModal
-            v-model="botListOpen"
-            :engineVersion="battle.battleOptions.engineVersion"
-            :teamId="botModalTeamId"
-            title="Add Bot"
-            @bot-selected="onBotSelected"
-        />
         <TeamComponent
             v-for="[teamId] in sortedTeams"
             :key="teamId"
@@ -174,46 +174,5 @@ const onDrop = (event: DragEvent, teamId: number) => {
     &.dragging .group > * {
         pointer-events: none;
     }
-}
-.group {
-    position: relative;
-    &:not(:last-child):after {
-        content: "";
-        display: flex;
-        background: rgba(255, 255, 255, 0.1);
-        width: 100%;
-        height: 1px;
-        margin: 10px 0;
-    }
-    &.highlight {
-        &:before {
-            @extend .fullsize;
-            width: calc(100% + 10px);
-            height: calc(100%);
-            left: -5px;
-            top: -5px;
-            background: rgba(255, 255, 255, 0.1);
-        }
-    }
-    &.highlight-error {
-        &:before {
-            @extend .fullsize;
-            width: calc(100% + 10px);
-            height: calc(100%);
-            left: -5px;
-            top: -5px;
-            background: rgba(255, 100, 100, 0.1);
-        }
-    }
-}
-.title {
-    font-size: 26px;
-}
-.participants {
-    display: flex;
-    flex-direction: row;
-    gap: 5px;
-    flex-wrap: wrap;
-    margin-top: 5px;
 }
 </style>

--- a/src/components/battle/Playerlist.vue
+++ b/src/components/battle/Playerlist.vue
@@ -5,8 +5,7 @@
             :engine-version="battle.battleOptions.engineVersion"
             :team-id="botModalTeamId"
             title="Add Bot"
-            @bot-selected="onBotSelected"
-        />
+            @bot-selected="onBotSelected" />
         <TeamComponent
             v-for="[teamId, name] in sortedTeams"
             :team-id="teamId"
@@ -48,18 +47,18 @@ const sortedTeams = computed(() => {
 });
 
 // This data is improperly cached, I'm unsure of the ideal way to fix it. I force it to refetch
-const engine = props.battle.battleOptions.engineVersion
+const engine = props.battle.battleOptions.engineVersion;
 await api.content.ai.processAis(engine);
 
 const openBotList = (teamId: number) => {
     botModalTeamId.value = teamId;
     botListOpen.value = true;
-}
+};
 
 const onBotSelected = (bot: string, teamId: number) => {
     botListOpen.value = false;
     addBot(bot, teamId);
-}
+};
 
 const addBot = (bot: string, teamId: number) => {
     let randomName = randomFromArray(aiNames);
@@ -108,18 +107,15 @@ const dragEnter = (event: DragEvent, teamId: number) => {
     // this is a little verbose, but previous syntax was very hard to read
     const playerMember = draggedParticipant.value as User;
     const botMember = draggedParticipant.value as Bot;
-    const isPlayer = 'battleStatus' in playerMember;
-    const isBot = 'teamId' in botMember;
+    const isPlayer = "battleStatus" in playerMember;
+    const isBot = "teamId" in botMember;
     const isSpectator = isPlayer && playerMember.battleStatus.isSpectator;
     const memberTeamId = playerMember?.battleStatus?.teamId ?? botMember.teamId;
 
-    const invalidMove =
-        (isBot && teamId < 0)
-        || (isSpectator && teamId < 0)
-        || (memberTeamId === teamId && !isSpectator);
+    const invalidMove = (isBot && teamId < 0) || (isSpectator && teamId < 0) || (memberTeamId === teamId && !isSpectator);
 
     if (groupEl) {
-        invalidMove ? groupEl.classList.add("highlight-error") : groupEl.classList.add("highlight")
+        invalidMove ? groupEl.classList.add("highlight-error") : groupEl.classList.add("highlight");
     }
 };
 
@@ -148,26 +144,26 @@ const dragEnd = () => {
 
 const onDrop = (event: DragEvent, teamId: number) => {
     const target = event.target as Element;
-    if(!draggedParticipant.value || target.getAttribute("data-type") !== "group") {
+    if (!draggedParticipant.value || target.getAttribute("data-type") !== "group") {
         return;
     }
-    const isPlayer = "userId" in draggedParticipant.value;
-    const playerIsSpectator = isPlayer ? (draggedParticipant.value as User).battleStatus.isSpectator : false;
+    const playerMember = draggedParticipant.value as User;
+    const isPlayer = "battleStatus" in playerMember;
+    const isSpectator = isPlayer && playerMember.battleStatus.isSpectator;
 
     if (teamId >= 0) {
         // move to team
-        if(isPlayer && !playerIsSpectator || !isPlayer) {
+        if ((isPlayer && !isSpectator) || !isPlayer) {
             props.battle.setContenderTeam(draggedParticipant.value, teamId);
-        } else if (isPlayer && playerIsSpectator) {
-            props.battle.spectatorToPlayer(draggedParticipant.value as User, teamId);
+        } else if (isPlayer && isSpectator) {
+            props.battle.spectatorToPlayer(playerMember, teamId);
         }
     } else {
         // move to spectate
-        if(isPlayer && !playerIsSpectator) {
-            props.battle.playerToSpectator(draggedParticipant.value as User);
+        if (isPlayer && !isSpectator) {
+            props.battle.playerToSpectator(playerMember);
         }
     }
-
 };
 </script>
 

--- a/src/components/battle/Playerlist.vue
+++ b/src/components/battle/Playerlist.vue
@@ -109,7 +109,6 @@ const openBotList = (teamId: number) => {
 }
 
 const onBotSelected = (bot: string, teamId: number) => {
-    console.log('adding bot to team', teamId);
     botListOpen.value = false;
     addBot(bot, teamId);
 }

--- a/src/components/battle/Playerlist.vue
+++ b/src/components/battle/Playerlist.vue
@@ -8,7 +8,7 @@
             @bot-selected="onBotSelected"
         />
         <div
-            v-for="[teamId, contenders] in battle.teams.value"
+            v-for="[teamId, contenders] in appendedTeams"
             :key="`team${teamId}`"
             class="group"
             data-type="group"
@@ -28,7 +28,13 @@
                 > Join </Button>
             </div>
             <div class="participants">
-                <div v-for="(contender, contenderIndex) in contenders" :key="`contender${contenderIndex}`" draggable @dragstart="dragStart($event, contender)" @dragend="dragEnd($event, contender)">
+                <div
+                    v-for="(contender, contenderIndex) in contenders"
+                    :key="`contender${contenderIndex}`"
+                    draggable
+                    @dragstart="dragStart($event, contender)"
+                    @dragend="dragEnd($event, contender)"
+                >
                     <PlayerParticipant v-if="'userId' in contender" :battle="battle" :player="contender" />
                     <BotParticipant v-else :battle="battle" :bot="contender" />
                 </div>
@@ -37,18 +43,10 @@
         <div
             class="group"
             data-type="group"
-            @dragenter.prevent="dragEnter($event, emptyTeamId)"
+            @dragenter.prevent="dragEnter($event)"
             @dragover.prevent
-            @dragleave.prevent="dragLeave($event, emptyTeamId)"
-            @drop="onDrop($event, emptyTeamId)"
-        >
-            <div class="flex-row gap-md">
-                <div class="title">Team {{ emptyTeamId + 1 }}</div>
-                <Button class="slim" @click="openBotList(emptyTeamId)"> Add bot </Button>
-                <Button class="slim" @click="joinTeam(emptyTeamId)"> Join </Button>
-            </div>
-        </div>
-        <div class="group" data-type="group" @dragenter.prevent="dragEnter($event)" @dragover.prevent @dragleave.prevent="dragLeave($event)" @drop="onDrop($event)">
+            @dragleave.prevent="dragLeave($event)"
+            @drop="onDrop($event)">
             <div class="flex-row gap-md">
                 <div class="title">Spectators ({{ battle.spectators.value.length }})</div>
                 <Button v-if="!me.battleStatus.isSpectator" class="slim" @click="joinTeam()"> Join </Button>
@@ -88,6 +86,11 @@ const props = defineProps<{
 }>();
 const botListOpen = ref(false);
 const botModalTeamId = ref(0);
+const appendedTeams = computed(() => {
+    const teams = props.battle.teams.value
+    teams.set(teams.size, []);
+    return teams;
+})
 
 // This data is improperly cached, I'm unsure of the ideal way to fix it. I force it to refetch
 const engine = props.battle.battleOptions.engineVersion

--- a/src/components/battle/Playerlist.vue
+++ b/src/components/battle/Playerlist.vue
@@ -5,7 +5,8 @@
             :engineVersion="battle.battleOptions.engineVersion"
             :teamId="botModalTeamId"
             title="Add Bot"
-            @bot-selected="onBotSelected" />
+            @bot-selected="onBotSelected"
+        />
         <TeamComponent
             v-for="[teamId] in sortedTeams"
             :key="teamId"

--- a/src/components/battle/TeamComponent.vue
+++ b/src/components/battle/TeamComponent.vue
@@ -17,7 +17,7 @@
             <div
                 v-for="(member, memberIndex) in members"
                 :key="`member${memberIndex}`"
-                draggable
+                draggable="true"
                 @dragstart="onDragStart($event, member)"
                 @dragend="onDragEnd()"
             >
@@ -94,15 +94,6 @@ function onDrop(event: DragEvent, teamId: number) {
 </script>
 
 <style lang="scss" scoped>
-.playerlist {
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    padding-right: 5px;
-    &.dragging .group > * {
-        pointer-events: none;
-    }
-}
 .group {
     position: relative;
     &:not(:last-child):after {
@@ -121,6 +112,16 @@ function onDrop(event: DragEvent, teamId: number) {
             left: -5px;
             top: -5px;
             background: rgba(255, 255, 255, 0.1);
+        }
+    }
+    &.highlight-error {
+        &:before {
+            @extend .fullsize;
+            width: calc(100% + 10px);
+            height: calc(100%);
+            left: -5px;
+            top: -5px;
+            background: rgba(255, 100, 100, 0.1);
         }
     }
 }

--- a/src/components/battle/TeamComponent.vue
+++ b/src/components/battle/TeamComponent.vue
@@ -7,8 +7,9 @@
         @dragover.prevent
         @drop="onDrop($event, teamId)"
     >
-        <div class="flex-row gap-md">
+        <div class="flex-row flex-center-items gap-md">
             <div class="title">{{title}}</div>
+            <div class="member-count">({{memberCount}} Members)</div>
             <Button
                 class="slim"
                 v-if="!isSpectator"
@@ -37,7 +38,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, Ref, ref } from "vue";
+import { computed } from "vue";
 
 import BotParticipant from "@/components/battle/BotParticipant.vue";
 import PlayerParticipant from "@/components/battle/PlayerParticipant.vue";
@@ -73,6 +74,11 @@ const showJoin = computed(() => {
     const listIsSpectator = props.teamId < 0;
 
     return playerTeam !== listTeam || (listIsSpectator && !playerIsSpectator);
+})
+const memberCount = computed(() => {
+    return isSpectator.value
+        ? props.battle.spectators.value.length
+        : props.battle.teams.value.get(props.teamId)?.length ?? 0;
 })
 
 const emit = defineEmits([
@@ -144,6 +150,12 @@ function onDrop(event: DragEvent, teamId: number) {
 }
 .title {
     font-size: 26px;
+}
+.member-count {
+    display: inline-block;
+    font-size: 20px;
+    opacity: 0.5;
+    vertical-align: middle;
 }
 .participants {
     display: flex;

--- a/src/components/battle/TeamComponent.vue
+++ b/src/components/battle/TeamComponent.vue
@@ -3,7 +3,7 @@
         :key="`team${teamId}`"
         class="group"
         data-type="group"
-        @dragenter.prevent="onDragEnter($event)"
+        @dragenter.prevent="onDragEnter($event, teamId)"
         @dragover.prevent
         @drop="onDrop($event, teamId)"
     >
@@ -100,8 +100,8 @@ function onDragEnd() {
     emit("onDragEnd");
 }
 
-function onDragEnter(event: DragEvent) {
-    emit("onDragEnter", event);
+function onDragEnter(event: DragEvent, teamId: number) {
+    emit("onDragEnter", event, teamId);
 }
 
 function onDrop(event: DragEvent, teamId: number) {

--- a/src/components/battle/TeamComponent.vue
+++ b/src/components/battle/TeamComponent.vue
@@ -1,0 +1,155 @@
+<template>
+    <div
+        :key="`team${teamId}`"
+        class="group"
+        data-type="group"
+        @dragenter.prevent="onDragEnter($event)"
+        @dragover.prevent
+        @drop="onDrop($event, teamId)"
+    >
+        <div class="flex-row gap-md">
+            <div class="title">{{title}}</div>
+            <Button
+                class="slim"
+                v-if="!isSpectator"
+                @click="addBotClicked(teamId)"
+            > Add bot </Button>
+
+            <Button
+                class="slim"
+                v-if="showJoin"
+                @click="onJoinClicked(teamId)"
+            > Join </Button>
+        </div>
+        <div class="participants">
+            <div
+                v-for="(member, memberIndex) in members"
+                :key="`member${memberIndex}`"
+                draggable
+                @dragstart="onDragStart($event, member)"
+                @dragend="onDragEnd()"
+            >
+                <PlayerParticipant v-if="'userId' in member" :battle="battle" :player="member" />
+                <BotParticipant v-else :battle="battle" :bot="member" />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, Ref, ref } from "vue";
+
+import BotParticipant from "@/components/battle/BotParticipant.vue";
+import PlayerParticipant from "@/components/battle/PlayerParticipant.vue";
+import Button from "@/components/controls/Button.vue";
+import { AbstractBattle } from "@/model/battle/abstract-battle";
+import { CurrentUser, User } from "@/model/user";
+import { Bot } from "@/model/battle/types";
+
+const props = defineProps<{
+    battle: AbstractBattle;
+    teamId: number;
+    me: CurrentUser;
+}>();
+
+// This data is improperly cached, I'm unsure of the ideal way to fix it. I force it to refetch
+const engine = props.battle.battleOptions.engineVersion
+await api.content.ai.processAis(engine);
+
+const isSpectator = computed(() => {
+    return props.teamId < 0;
+});
+const title = computed(() => {
+    return isSpectator.value ? "Spectators" : "Team " + (props.teamId + 1);
+})
+const members = computed(() => {
+    const battle = props.battle;
+    return isSpectator.value ? battle.spectators.value : battle.teams.value.get(props.teamId);
+});
+const showJoin = computed(() => {
+    const playerIsSpectator = props.me.battleStatus.isSpectator;
+    const playerTeam = playerIsSpectator ? -1 : props.me.battleStatus.teamId;
+    const listTeam = props.teamId;
+    const listIsSpectator = props.teamId < 0;
+
+    return playerTeam !== listTeam || (listIsSpectator && !playerIsSpectator);
+})
+
+const emit = defineEmits([
+    "addBotClicked",
+    "onJoinClicked",
+    "onDragStart",
+    "onDragEnd",
+    "onDragEnter",
+    "onDrop",
+]);
+
+function addBotClicked(teamId: number) {
+    emit("addBotClicked", teamId);
+}
+
+function onJoinClicked(teamId: number) {
+    emit("onJoinClicked", teamId);
+}
+
+function onDragStart(event: DragEvent, member: User | Bot) {
+    emit("onDragStart", event, member);
+}
+
+function onDragEnd() {
+    emit("onDragEnd");
+}
+
+function onDragEnter(event: DragEvent) {
+    emit("onDragEnter", event);
+}
+
+function onDrop(event: DragEvent, teamId: number) {
+    emit("onDrop", event, teamId);
+}
+
+
+</script>
+
+<style lang="scss" scoped>
+.playerlist {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    padding-right: 5px;
+    &.dragging .group > * {
+        pointer-events: none;
+    }
+}
+.group {
+    position: relative;
+    &:not(:last-child):after {
+        content: "";
+        display: flex;
+        background: rgba(255, 255, 255, 0.1);
+        width: 100%;
+        height: 1px;
+        margin: 10px 0;
+    }
+    &.highlight {
+        &:before {
+            @extend .fullsize;
+            width: calc(100% + 10px);
+            height: calc(100%);
+            left: -5px;
+            top: -5px;
+            background: rgba(255, 255, 255, 0.1);
+        }
+    }
+}
+.title {
+    font-size: 26px;
+}
+.participants {
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+    flex-wrap: wrap;
+    margin-top: 5px;
+}
+</style>

--- a/src/components/battle/TeamComponent.vue
+++ b/src/components/battle/TeamComponent.vue
@@ -8,19 +8,11 @@
         @drop="onDrop($event, teamId)"
     >
         <div class="flex-row flex-center-items gap-md">
-            <div class="title">{{title}}</div>
-            <div class="member-count">({{memberCount}} Members)</div>
-            <Button
-                class="slim"
-                v-if="!isSpectator"
-                @click="addBotClicked(teamId)"
-            > Add bot </Button>
+            <div class="title">{{ title }}</div>
+            <div class="member-count">({{ memberCount }} Members)</div>
+            <Button class="slim" v-if="!isSpectator" @click="addBotClicked(teamId)"> Add bot </Button>
 
-            <Button
-                class="slim"
-                v-if="showJoin"
-                @click="onJoinClicked(teamId)"
-            > Join </Button>
+            <Button class="slim" v-if="showJoin" @click="onJoinClicked(teamId)"> Join </Button>
         </div>
         <div class="participants">
             <div
@@ -54,7 +46,7 @@ const props = defineProps<{
 }>();
 
 // This data is improperly cached, I'm unsure of the ideal way to fix it. I force it to refetch
-const engine = props.battle.battleOptions.engineVersion
+const engine = props.battle.battleOptions.engineVersion;
 await api.content.ai.processAis(engine);
 
 const isSpectator = computed(() => {
@@ -62,7 +54,7 @@ const isSpectator = computed(() => {
 });
 const title = computed(() => {
     return isSpectator.value ? "Spectators" : "Team " + (props.teamId + 1);
-})
+});
 const members = computed(() => {
     const battle = props.battle;
     return isSpectator.value ? battle.spectators.value : battle.teams.value.get(props.teamId);
@@ -74,21 +66,12 @@ const showJoin = computed(() => {
     const listIsSpectator = props.teamId < 0;
 
     return playerTeam !== listTeam || (listIsSpectator && !playerIsSpectator);
-})
+});
 const memberCount = computed(() => {
-    return isSpectator.value
-        ? props.battle.spectators.value.length
-        : props.battle.teams.value.get(props.teamId)?.length ?? 0;
-})
+    return isSpectator.value ? props.battle.spectators.value.length : props.battle.teams.value.get(props.teamId)?.length ?? 0;
+});
 
-const emit = defineEmits([
-    "addBotClicked",
-    "onJoinClicked",
-    "onDragStart",
-    "onDragEnd",
-    "onDragEnter",
-    "onDrop",
-]);
+const emit = defineEmits(["addBotClicked", "onJoinClicked", "onDragStart", "onDragEnd", "onDragEnter", "onDrop"]);
 
 function addBotClicked(teamId: number) {
     emit("addBotClicked", teamId);
@@ -113,8 +96,6 @@ function onDragEnter(event: DragEvent, teamId: number) {
 function onDrop(event: DragEvent, teamId: number) {
     emit("onDrop", event, teamId);
 }
-
-
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/battle/TeamComponent.vue
+++ b/src/components/battle/TeamComponent.vue
@@ -9,10 +9,9 @@
     >
         <div class="flex-row flex-center-items gap-md">
             <div class="title">{{ title }}</div>
-            <div class="member-count" v-if="memberCount > 0">({{ memberCount }} Members)</div>
-            <Button class="slim" v-if="!isSpectator" @click="addBotClicked(teamId)"> Add bot </Button>
-
-            <Button class="slim" v-if="showJoin" @click="onJoinClicked(teamId)"> Join </Button>
+            <div v-if="memberCount > 0" class="member-count">({{ memberCount }} Members)</div>
+            <Button v-if="!isSpectator" class="slim" @click="addBotClicked(teamId)"> Add bot </Button>
+            <Button v-if="showJoin" class="slim" @click="onJoinClicked(teamId)"> Join </Button>
         </div>
         <div class="participants">
             <div
@@ -36,18 +35,14 @@ import BotParticipant from "@/components/battle/BotParticipant.vue";
 import PlayerParticipant from "@/components/battle/PlayerParticipant.vue";
 import Button from "@/components/controls/Button.vue";
 import { AbstractBattle } from "@/model/battle/abstract-battle";
-import { CurrentUser, User } from "@/model/user";
 import { Bot } from "@/model/battle/types";
+import { CurrentUser, User } from "@/model/user";
 
 const props = defineProps<{
     battle: AbstractBattle;
     teamId: number;
     me: CurrentUser;
 }>();
-
-// This data is improperly cached, I'm unsure of the ideal way to fix it. I force it to refetch
-const engine = props.battle.battleOptions.engineVersion;
-await api.content.ai.processAis(engine);
 
 const isSpectator = computed(() => {
     return props.teamId < 0;

--- a/src/components/battle/TeamComponent.vue
+++ b/src/components/battle/TeamComponent.vue
@@ -9,7 +9,7 @@
     >
         <div class="flex-row flex-center-items gap-md">
             <div class="title">{{ title }}</div>
-            <div class="member-count">({{ memberCount }} Members)</div>
+            <div class="member-count" v-if="memberCount > 0">({{ memberCount }} Members)</div>
             <Button class="slim" v-if="!isSpectator" @click="addBotClicked(teamId)"> Add bot </Button>
 
             <Button class="slim" v-if="showJoin" @click="onJoinClicked(teamId)"> Join </Button>

--- a/src/components/common/ContextMenu.vue
+++ b/src/components/common/ContextMenu.vue
@@ -1,5 +1,15 @@
 <template>
-    <Popper v-click-away="() => (show = false)" v-bind="$attrs" openDelay="0" closeDelay="0" offsetDistance="0" :show="show" placement="right-start" class="context-menu" @click.right="show = true">
+    <Popper
+        v-click-away="() => (show = false)"
+        v-bind="$attrs"
+        openDelay="0"
+        closeDelay="0"
+        offsetDistance="0"
+        :show="show"
+        placement="right-start"
+        class="context-menu"
+        @click.right="show = true"
+    >
         <slot />
         <template #content>
             <div v-for="entry in props.entries" :key="entry.label" class="context-menu__entry">

--- a/src/components/common/Panel.vue
+++ b/src/components/common/Panel.vue
@@ -54,8 +54,8 @@ const props = withDefaults(
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-top: 1px solid rgba(255, 255, 255, 0.3);
     border-bottom: 1px solid rgba(124, 124, 124, 0.3);
-    box-shadow: -1px 0 0 rgba(0, 0, 0, 0.3), 1px 0 0 rgba(0, 0, 0, 0.3), 0 1px 0 rgba(0, 0, 0, 0.3), 0 -1px 0 rgba(0, 0, 0, 0.3), inset 0 0 50px rgba(255, 255, 255, 0.15),
-        inset 0 3px 8px rgba(255, 255, 255, 0.1), 3px 3px 10px rgba(0, 0, 0, 0.8);
+    box-shadow: -1px 0 0 rgba(0, 0, 0, 0.3), 1px 0 0 rgba(0, 0, 0, 0.3), 0 1px 0 rgba(0, 0, 0, 0.3), 0 -1px 0 rgba(0, 0, 0, 0.3),
+        inset 0 0 50px rgba(255, 255, 255, 0.15), inset 0 3px 8px rgba(255, 255, 255, 0.1), 3px 3px 10px rgba(0, 0, 0, 0.8);
     &.empty {
         background: transparent;
         backdrop-filter: none;

--- a/src/components/controls/Range.vue
+++ b/src/components/controls/Range.vue
@@ -1,7 +1,14 @@
 <template>
     <Control class="range">
         <Slider ref="slider" v-bind="$attrs" :modelValue="modelValue" @update:model-value="onSlide" />
-        <InputNumber v-if="typeof modelValue === 'number'" :modelValue="modelValue" :step="props.step" :min="props.min" :max="props.max" @update:model-value="onInput" />
+        <InputNumber
+            v-if="typeof modelValue === 'number'"
+            :modelValue="modelValue"
+            :step="props.step"
+            :min="props.min"
+            :max="props.max"
+            @update:model-value="onInput"
+        />
     </Control>
 </template>
 

--- a/src/components/login/RegisterForm.vue
+++ b/src/components/login/RegisterForm.vue
@@ -8,7 +8,14 @@
             <Textbox v-model="email" type="email" label="Email" required class="fullwidth" />
             <Textbox v-model="username" label="Username" required class="fullwidth" />
             <Textbox v-model="password" type="password" label="Password" required class="fullwidth" />
-            <Textbox v-model="confirmPassword" type="password" label="Confirm Password" :validation="validatePassword" required class="fullwidth" />
+            <Textbox
+                v-model="confirmPassword"
+                type="password"
+                label="Confirm Password"
+                :validation="validatePassword"
+                required
+                class="fullwidth"
+            />
             <Button type="submit" class="blue"> Register </Button>
         </form>
     </div>
@@ -39,7 +46,11 @@ const validatePassword = (value: string) => {
 const register = async () => {
     loading.value = true;
 
-    const registerResponse = await api.comms.request("c.auth.register", { email: email.value, username: username.value, password: password.value });
+    const registerResponse = await api.comms.request("c.auth.register", {
+        email: email.value,
+        username: username.value,
+        password: password.value,
+    });
 
     if (registerResponse.result === "success") {
         error.value = "";

--- a/src/components/login/ResetPasswordForm.vue
+++ b/src/components/login/ResetPasswordForm.vue
@@ -2,7 +2,14 @@
     <form ref="form" class="flex-col gap-md" @submit.prevent="requestPasswordReset">
         NOT IMPLEMENTED
         <p>Provide your account's email address <b>or</b> username to request a password reset</p>
-        <Textbox v-model="email" type="email" label="Email" :required="!Boolean(username)" class="fullwidth" :disabled="Boolean(username)" />
+        <Textbox
+            v-model="email"
+            type="email"
+            label="Email"
+            :required="!Boolean(username)"
+            class="fullwidth"
+            :disabled="Boolean(username)"
+        />
         <Textbox v-model="username" label="Username" :required="!Boolean(email)" class="fullwidth" :disabled="Boolean(email)" />
         <Button type="submit" class="blue"> Request Password Reset </Button>
     </form>

--- a/src/components/misc/DebugSidebar.vue
+++ b/src/components/misc/DebugSidebar.vue
@@ -5,7 +5,15 @@
                 <Icon :icon="tools" :height="20" />
             </Button>
         </div>
-        <Select :modelValue="currentRoute" label="View" :options="routes" :filter="true" optionLabel="path" optionValue="path" :placeholder="currentRoute" />
+        <Select
+            :modelValue="currentRoute"
+            label="View"
+            :options="routes"
+            :filter="true"
+            optionLabel="path"
+            optionValue="path"
+            :placeholder="currentRoute"
+        />
         <Button to="/debug"> Debug Sandbox </Button>
         <Button @click="openSettings"> Open Settings File </Button>
         <Button @click="openContentDir"> Open Content Dir </Button>

--- a/src/components/misc/ReplayPreview.vue
+++ b/src/components/misc/ReplayPreview.vue
@@ -1,13 +1,25 @@
 <template>
     <div class="flex-col gap-md">
-        <MapPreview :map="replay.mapScriptName" :isSpectator="true" :myTeamId="0" :startBoxes="startBoxes" :startPosType="startPosType" :startPositions="startPositions" />
+        <MapPreview
+            :map="replay.mapScriptName"
+            :isSpectator="true"
+            :myTeamId="0"
+            :startBoxes="startBoxes"
+            :startPosType="startPosType"
+            :startPositions="startPositions"
+        />
 
         <div v-if="replay.preset === 'ffa'">
             <div class="team-title">Players</div>
             <div class="contenders">
                 <template v-for="(contender, contenderIndex) in replay.contenders" :key="`contender${contenderIndex}`">
                     <ReplayParticipant :contender="contender" />
-                    <Icon v-if="replay.winningTeamId === contender.allyTeamId && showSpoilers" class="trophy" :icon="trophyVariant" height="18" />
+                    <Icon
+                        v-if="replay.winningTeamId === contender.allyTeamId && showSpoilers"
+                        class="trophy"
+                        :icon="trophyVariant"
+                        height="18"
+                    />
                 </template>
             </div>
         </div>
@@ -18,14 +30,22 @@
                 <Icon v-if="replay.winningTeamId === teamId && showSpoilers" class="trophy" :icon="trophyVariant" height="18" />
             </div>
             <div class="contenders">
-                <ReplayParticipant v-for="(contender, contenderIndex) in contenders" :key="`contender${contenderIndex}`" :contender="contender" />
+                <ReplayParticipant
+                    v-for="(contender, contenderIndex) in contenders"
+                    :key="`contender${contenderIndex}`"
+                    :contender="contender"
+                />
             </div>
         </div>
 
         <div v-if="replay.spectators.length">
             <div class="team-title">Spectators</div>
             <div class="contenders">
-                <ReplayParticipant v-for="(spectator, spectatorIndex) in replay.spectators" :key="`spectator${spectatorIndex}`" :contender="spectator" />
+                <ReplayParticipant
+                    v-for="(spectator, spectatorIndex) in replay.spectators"
+                    :key="`spectator${spectatorIndex}`"
+                    :contender="spectator"
+                />
             </div>
         </div>
 

--- a/src/components/navbar/Downloads.vue
+++ b/src/components/navbar/Downloads.vue
@@ -10,7 +10,11 @@
                         {{ download.type }}
                     </div>
                 </div>
-                <Progress :percent="download.currentBytes / download.totalBytes" :text="progressText(download.currentBytes, download.totalBytes)" themed />
+                <Progress
+                    :percent="download.currentBytes / download.totalBytes"
+                    :text="progressText(download.currentBytes, download.totalBytes)"
+                    themed
+                />
             </div>
         </div>
         <div v-else class="flex-row flex-grow flex-center">No downloads active</div>
@@ -27,7 +31,9 @@ const emits = defineEmits<{
     (e: "percentChange", newPercent: number): void;
 }>();
 
-const downloads = computed(() => api.content.engine.currentDownloads.concat(api.content.game.currentDownloads, api.content.maps.currentDownloads));
+const downloads = computed(() =>
+    api.content.engine.currentDownloads.concat(api.content.game.currentDownloads, api.content.maps.currentDownloads)
+);
 
 const progressText = (currentBytes: number, totalBytes: number) => {
     const percent = currentBytes / totalBytes;

--- a/src/components/navbar/DownloadsButton.vue
+++ b/src/components/navbar/DownloadsButton.vue
@@ -35,14 +35,16 @@ const downloadPercent = computed(() => {
         top: 0;
         left: 1px;
         z-index: -1;
-        background: radial-gradient(ellipse at top, hsla(69, 100%, 50%, 0.685), transparent), radial-gradient(ellipse at bottom, #2c4e05c7, transparent);
+        background: radial-gradient(ellipse at top, hsla(69, 100%, 50%, 0.685), transparent),
+            radial-gradient(ellipse at bottom, #2c4e05c7, transparent);
         background-repeat: no-repeat;
         background-position: 0 100%;
         background-size: 100% var(--downloadPercent);
         transform: scale(105%);
     }
     &:hover:before {
-        background: radial-gradient(ellipse at top, hsla(69, 100%, 50%, 0.884), transparent), radial-gradient(ellipse at bottom, #4b830a, transparent);
+        background: radial-gradient(ellipse at top, hsla(69, 100%, 50%, 0.884), transparent),
+            radial-gradient(ellipse at bottom, #4b830a, transparent);
         background-size: 100% var(--downloadPercent);
         background-repeat: no-repeat;
         background-position: 0 100%;

--- a/src/components/navbar/Friends.vue
+++ b/src/components/navbar/Friends.vue
@@ -18,12 +18,22 @@
                     <Accordion :activeIndex="accordianActiveIndexes" multiple>
                         <AccordionTab v-if="outgoingFriendRequests.length" header="Outgoing Friend Requests">
                             <div class="user-list">
-                                <Friend v-for="(user, i) in outgoingFriendRequests" :key="`outgoingFriendRequest${i}`" :user="user" :type="'outgoing_request'" />
+                                <Friend
+                                    v-for="(user, i) in outgoingFriendRequests"
+                                    :key="`outgoingFriendRequest${i}`"
+                                    :user="user"
+                                    :type="'outgoing_request'"
+                                />
                             </div>
                         </AccordionTab>
                         <AccordionTab v-if="incomingFriendRequests.length" header="Incoming Friend Requests">
                             <div class="user-list">
-                                <Friend v-for="(user, i) in incomingFriendRequests" :key="`incomingFriendRequest${i}`" :user="user" :type="'incoming_request'" />
+                                <Friend
+                                    v-for="(user, i) in incomingFriendRequests"
+                                    :key="`incomingFriendRequest${i}`"
+                                    :user="user"
+                                    :type="'incoming_request'"
+                                />
                             </div>
                         </AccordionTab>
                         <AccordionTab v-if="onlineFriends.length" header="Online">

--- a/src/components/navbar/NavBar.vue
+++ b/src/components/navbar/NavBar.vue
@@ -82,7 +82,9 @@ const primaryRoutes = allRoutes
     .sort((a, b) => (a.meta.order ?? 99) - (b.meta.order ?? 99));
 
 const secondaryRoutes = computed(() => {
-    return allRoutes.filter((r) => r.meta.order !== undefined && r.path.startsWith(`/${route.path.split("/")[1]}/`)).sort((a, b) => (a.meta.order ?? 99) - (b.meta.order ?? 99));
+    return allRoutes
+        .filter((r) => r.meta.order !== undefined && r.path.startsWith(`/${route.path.split("/")[1]}/`))
+        .sort((a, b) => (a.meta.order ?? 99) - (b.meta.order ?? 99));
 });
 
 const downloadsOpen = ref(false);
@@ -172,7 +174,8 @@ const serverOffline = api.session.offlineMode;
             background: radial-gradient(rgba(0, 0, 0, 0), rgba(255, 255, 255, 0.15));
             color: #fff;
             text-shadow: 0 0 7px #fff;
-            box-shadow: 1px 0 0 rgba(255, 255, 255, 0.2), -1px 0 0 rgba(255, 255, 255, 0.2), 0 1px 0 rgba(255, 255, 255, 0.2), 7px -3px 10px rgba(0, 0, 0, 0.5), -7px -3px 10px rgba(0, 0, 0, 0.5) !important;
+            box-shadow: 1px 0 0 rgba(255, 255, 255, 0.2), -1px 0 0 rgba(255, 255, 255, 0.2), 0 1px 0 rgba(255, 255, 255, 0.2),
+                7px -3px 10px rgba(0, 0, 0, 0.5), -7px -3px 10px rgba(0, 0, 0, 0.5) !important;
         }
         &.active {
             z-index: 1;
@@ -236,7 +239,8 @@ const serverOffline = api.session.offlineMode;
 }
 .button.close:hover {
     background: rgba(255, 0, 0, 0.2);
-    box-shadow: 1px 0 0 rgba(255, 47, 47, 0.418), -1px 0 0 rgba(255, 47, 47, 0.418), 0 1px 0 rgba(255, 47, 47, 0.418), 7px -3px 10px rgba(0, 0, 0, 0.5), -7px -3px 10px rgba(0, 0, 0, 0.5) !important;
+    box-shadow: 1px 0 0 rgba(255, 47, 47, 0.418), -1px 0 0 rgba(255, 47, 47, 0.418), 0 1px 0 rgba(255, 47, 47, 0.418),
+        7px -3px 10px rgba(0, 0, 0, 0.5), -7px -3px 10px rgba(0, 0, 0, 0.5) !important;
 }
 .server-status-dot {
     font-size: 12px;

--- a/src/model/ai.ts
+++ b/src/model/ai.ts
@@ -1,6 +1,6 @@
 import { LuaOptionSection } from "@/model/lua-options";
 
-export type AI = {
+export type EngineAI = {
     shortName: string;
     name: string;
     version: string;
@@ -12,3 +12,37 @@ export type AI = {
     ddlPath: string;
     options: LuaOptionSection[];
 };
+
+/*
+ * TODO:
+ *  All this stuff is gross, I just copied the behavior from chobby which is... eh
+ *  Would love to find a better way to handle the distinction between engine AI and game AI
+ */
+
+export const gameAis = ["ChickensAI", "ScavengersAI", "SimpleAI", "SimpleDefenderAI", "SimpleConstructorAI", "ControlModeAI", ];
+
+export const aiDescription = new Map<string, string>([
+    ['SimpleAI', "A simple, easy playing beginner AI (Great for your first game!)"],
+    ['SimpleDefenderAI', "An easy AI, mostly defends and doesnt attack much"],
+    ['ScavengersAI', "This is a PvE game mode, with an increasing difficulty waves of Scavenger AI controlled units attacking the players. Only add 1 per game."],
+    ['STAI', "A medium to hard difficulty, experimental, non cheating AI."],
+    ['NullAI', "A game-testing AI. Literally does nothing."],
+    ['BARb', "The recommended excellent performance, adjustable difficulty, non-cheating AI. Add as many as you wish!"],
+    ['ChickensAI', "This is a PvE game mode, where hordes of alien creatures attack the players. Only add 1 per game."],
+]);
+
+const aiFriendlyName = new Map<string, string>([
+    ['BARb', "BARbarian AI"],
+    ['NullAI', "Inactive AI"],
+    ['ScavengersAI', "ScavengersDefense AI"],
+    ['ChickensAI', "RaptorsDefense AI"],
+    ['STAI', "STAI"],
+]);
+
+export function getAiFriendlyName(name: string) {
+    return aiFriendlyName.get(name) ?? name;
+}
+
+export function getAiDescription(name: string) {
+    return aiDescription.get(name) ?? "";
+}

--- a/src/model/ai.ts
+++ b/src/model/ai.ts
@@ -23,31 +23,23 @@ export type EngineAI = {
  * chobby did not add STAI manually, but it doesn't show as an engine AI, I do not know how chobby
  * gets it in the UI. Adding it manually here seems to work.
  */
-export const gameAis = [
-    "ChickensAI",
-    "ScavengersAI",
-    "STAI",
-    "SimpleAI",
-    "SimpleDefenderAI",
-    "SimpleConstructorAI",
-    "ControlModeAI",
-];
+export const gameAis = ["ChickensAI", "ScavengersAI", "STAI", "SimpleAI", "SimpleDefenderAI", "SimpleConstructorAI", "ControlModeAI"];
 
 export const aiDescription = new Map<string, string>([
-    ['SimpleAI', "A simple, easy playing beginner AI (Great for your first game!)"],
-    ['SimpleDefenderAI', "An easy AI, mostly defends and doesnt attack much"],
-    ['ScavengersAI', "This is a PvE game mode, with an increasing difficulty waves of Scavenger AI controlled units attacking the players. Only add 1 per game."],
-    ['STAI', "A medium to hard difficulty, experimental, non cheating AI."],
-    ['NullAI', "A game-testing AI. Literally does nothing."],
-    ['BARb', "The recommended excellent performance, adjustable difficulty, non-cheating AI. Add as many as you wish!"],
-    ['ChickensAI', "This is a PvE game mode, where hordes of alien creatures attack the players. Only add 1 per game."],
+    ["SimpleAI", "A simple, easy playing beginner AI (Great for your first game!)"],
+    ["SimpleDefenderAI", "An easy AI, mostly defends and doesnt attack much"],
+    ["ScavengersAI", "This is a PvE game mode, with an increasing difficulty waves of Scavenger AI controlled units attacking the players. Only add 1 per game."],
+    ["STAI", "A medium to hard difficulty, experimental, non cheating AI."],
+    ["NullAI", "A game-testing AI. Literally does nothing."],
+    ["BARb", "The recommended excellent performance, adjustable difficulty, non-cheating AI. Add as many as you wish!"],
+    ["ChickensAI", "This is a PvE game mode, where hordes of alien creatures attack the players. Only add 1 per game."],
 ]);
 
 const aiFriendlyName = new Map<string, string>([
-    ['BARb', "BARbarian AI"],
-    ['NullAI', "Inactive AI"],
-    ['ScavengersAI', "ScavengersDefense AI"],
-    ['ChickensAI', "RaptorsDefense AI"],
+    ["BARb", "BARbarian AI"],
+    ["NullAI", "Inactive AI"],
+    ["ScavengersAI", "ScavengersDefense AI"],
+    ["ChickensAI", "RaptorsDefense AI"],
 ]);
 
 export function getAiFriendlyName(name: string) {

--- a/src/model/ai.ts
+++ b/src/model/ai.ts
@@ -19,7 +19,19 @@ export type EngineAI = {
  *  Would love to find a better way to handle the distinction between engine AI and game AI
  */
 
-export const gameAis = ["ChickensAI", "ScavengersAI", "SimpleAI", "SimpleDefenderAI", "SimpleConstructorAI", "ControlModeAI", ];
+/*
+ * chobby did not add STAI manually, but it doesn't show as an engine AI, I do not know how chobby
+ * gets it in the UI. Adding it manually here seems to work.
+ */
+export const gameAis = [
+    "ChickensAI",
+    "ScavengersAI",
+    "STAI",
+    "SimpleAI",
+    "SimpleDefenderAI",
+    "SimpleConstructorAI",
+    "ControlModeAI",
+];
 
 export const aiDescription = new Map<string, string>([
     ['SimpleAI', "A simple, easy playing beginner AI (Great for your first game!)"],
@@ -36,7 +48,6 @@ const aiFriendlyName = new Map<string, string>([
     ['NullAI', "Inactive AI"],
     ['ScavengersAI', "ScavengersDefense AI"],
     ['ChickensAI', "RaptorsDefense AI"],
-    ['STAI', "STAI"],
 ]);
 
 export function getAiFriendlyName(name: string) {

--- a/src/model/battle/abstract-battle.ts
+++ b/src/model/battle/abstract-battle.ts
@@ -35,7 +35,7 @@ export abstract class AbstractBattle {
         this.bots = reactive(config.bots);
         this.users = shallowReactive(config.users); // users already reactive
 
-        this.participants = computed(() => [...this.bots, ...this.users]);
+        this.participants = computed(() => [...this.users, ...this.bots]);
         this.contenders = computed(() => this.participants.value.filter((participant) => ("userId" in participant ? !participant.battleStatus.isSpectator : true)));
         this.players = computed(() => this.users.filter((user) => !user.battleStatus.isSpectator));
         this.spectators = computed(() => this.users.filter((user) => user.battleStatus.isSpectator));

--- a/src/model/battle/offline-battle.ts
+++ b/src/model/battle/offline-battle.ts
@@ -18,6 +18,7 @@ export class OfflineBattle extends AbstractBattle {
 
     public setEngine(engineVersion: string) {
         this.battleOptions.engineVersion = engineVersion;
+        api.content.ai.processAis(engineVersion);
     }
 
     public setGame(gameVersion: string) {

--- a/src/utils/start-script-converter.ts
+++ b/src/utils/start-script-converter.ts
@@ -124,6 +124,7 @@ export class StartScriptConverter {
         return {
             gametype: battle.battleOptions.gameVersion,
             mapname: battle.battleOptions.map,
+            modoptions: battle.battleOptions.gameOptions,
             ishost: 1,
             myplayername: api.session.offlineUser.username,
             startpostype: battle.battleOptions.startPosType,

--- a/src/views/debug/controls.vue
+++ b/src/views/debug/controls.vue
@@ -17,9 +17,31 @@
             <div class="value">{{ text }}</div>
         </div>
         <div class="flex-row gap-md flex-center-items">
-            <Select :modelValue="selection" :options="selections" optionLabel="name" optionValue="value" :placeholder="selection" @update:model-value="onUpdateSelection" />
-            <Select v-model="selection" :options="selections" label="Label" optionLabel="name" optionValue="value" :placeholder="selection" :filter="true" />
-            <Select v-model="selection" :options="selections" optionLabel="name" optionValue="value" :placeholder="selection" :disabled="true" />
+            <Select
+                :modelValue="selection"
+                :options="selections"
+                optionLabel="name"
+                optionValue="value"
+                :placeholder="selection"
+                @update:model-value="onUpdateSelection"
+            />
+            <Select
+                v-model="selection"
+                :options="selections"
+                label="Label"
+                optionLabel="name"
+                optionValue="value"
+                :placeholder="selection"
+                :filter="true"
+            />
+            <Select
+                v-model="selection"
+                :options="selections"
+                optionLabel="name"
+                optionValue="value"
+                :placeholder="selection"
+                :disabled="true"
+            />
             <div class="value">{{ selection }}</div>
         </div>
         <div class="flex-row gap-md flex-center-items">
@@ -42,7 +64,14 @@
         </div>
         <div class="flex-row">
             <Textbox v-model="text" />
-            <Select v-model="selection" :options="selections" optionLabel="name" optionValue="value" :placeholder="selection" :filter="true" />
+            <Select
+                v-model="selection"
+                :options="selections"
+                optionLabel="name"
+                optionValue="value"
+                :placeholder="selection"
+                :filter="true"
+            />
             <Range v-model="range" />
             <Checkbox v-model="checked" />
             <Options v-model="option" :options="options" />

--- a/src/views/debug/playground.vue
+++ b/src/views/debug/playground.vue
@@ -4,7 +4,14 @@
 
 <template>
     <div>
-        <Select :modelValue="selection" :options="selections" optionLabel="name" optionValue="value" :placeholder="selection" @update:model-value="onUpdateSelection" />
+        <Select
+            :modelValue="selection"
+            :options="selections"
+            optionLabel="name"
+            optionValue="value"
+            :placeholder="selection"
+            @update:model-value="onUpdateSelection"
+        />
     </div>
 </template>
 

--- a/src/views/library/replays.vue
+++ b/src/views/library/replays.vue
@@ -99,7 +99,9 @@ const replayDataToPreview = (replayData: Replay): ReplayPreviewData => {
 
     const date = format(replayData.startTime, "yyyy/MM/dd hh:mm a"); // https://date-fns.org/v2.29.3/docs/format
     const durtationValues = intervalToDuration({ start: 0, end: replayData.gameDurationMs });
-    const duration = `${durtationValues.hours}:${durtationValues.minutes?.toString().padStart(2, "0")}:${durtationValues.seconds?.toString().padStart(2, "0")}`;
+    const duration = `${durtationValues.hours}:${durtationValues.minutes?.toString().padStart(2, "0")}:${durtationValues.seconds
+        ?.toString()
+        .padStart(2, "0")}`;
     const map = replayData.mapScriptName;
     const game = replayData.gameVersion;
     const engine = replayData.engineVersion;


### PR DESCRIPTION
### Overview
- Added non-engine AI support
- Broke up the playerlist component for better readability and easier customization
- Fixed and improved drag-and-drop between team behavior (shows invalid moves)
- Configuration on right-click will now only show up on bots that have configuration options (only engine AI's)

### Testing notes
Engine AI's will not work on engine version `105.1.1-1375-gd2541c7 BAR105`, I don't know why. I've reported it and it seems out of scope with this PR, so make sure you're on an older version to test.

This PR is offline only. Online support will require a lot of API knowledge that I do not have yet. Looking forward to learning though 🙂 

### Bot setup
This is copied almost 1:1 from chobby - I'm quite certain this is not the best way to do things (a bunch of hardcoded strings in a TS file) and it definitely does not have localization support in its current state. I'm not sure how important that is at this stage. In particular the merging of the engine AI's and the game AI's in `ai-content.ts` could use some validation. 

Another thing that I tried to do but ultimately abandoned was setting up some stronger types for the game AI's. Ultimately I gave up because it ended up being even uglier than what we have, and it was hard to marry with the engine AI's - if you have a good solution for this that would be great.

Lastly, the caching of engine bots seems broken. I'm not sure how this was supposed to work so I just forced it to reprocess. Maybe not ideal, but I don't imagine there's a performance problem here so it's probably ok.

### Opinionated changes
Breaking up the views is not required, but it made the changes I wanted easier and it should enable easier adjustment in the future (i.e. showing teams as columns instead of rows is a change I'd like to make in the future).

For handling the UI, I've designated specs with a `teamId` of `-1` for simplicity of handling them the same way as other teams so all the UI code can be shared. The scope of this is completely limited to `TeamComponent` and `Playerlist`, so it won't mess with anything else.

I set up prettier line-lengths for `.vue` files. This is just a readability change, I got tired of prettier putting all the view component parameters on the same line, it made things very annoying to read and adjust. I know you have a pre-existing setup that I'm sure you prefer so this can be rolled back if needed, but I really would like a way to keep those longer component declarations in vue html as multi-line if possible.

### Todo
Preventing scav/raptors from getting one of the pre-selected AI names. I know there are vague plans for a better UI for raptor/scav specifically so I did not bother implementing that in this PR. Once in-game, the game takes over and just calls them by the AI name, not the one assigned by the lobby, so it's not that big of a deal.
