### PR TITLE
Search battles by map and player names, save battle filter settings

### DIFF
--- a/src/common/model/settings.ts
+++ b/src/common/model/settings.ts
@@ -8,4 +8,8 @@ export const settingsSchema = Type.Object({
     musicVolume: Type.Number({ default: 5, minimum: 0, maximum: 100 }),
     loginAutomatically: Type.Boolean({ default: true }),
     devMode: Type.Boolean({ default: false }),
+    battlesHideInProgress: Type.Boolean({ default: false }),
+    battlesHidePvE: Type.Boolean({ default: false }),
+    battlesHideLocked: Type.Boolean({ default: false }),
+    battlesHideEmpty: Type.Boolean({ default: true }),
 });

--- a/src/renderer/views/multiplayer/custom.vue
+++ b/src/renderer/views/multiplayer/custom.vue
@@ -11,11 +11,12 @@
 
             <div class="flex-row gap-md">
                 <Button class="blue" @click="hostBattleOpen = true">Host Battle</Button>
-                <HostBattle v-model="hostBattleOpen" />
-                <Checkbox v-model="hidePvE" label="Hide PvE" />
-                <Checkbox v-model="hideLocked" label="Hide Locked" />
-                <Checkbox v-model="hideEmpty" label="Hide Empty" />
-                <SearchBox v-model="searchVal" />
+                <HostBattle v-model="hostBattleOpen"/>
+                <Checkbox v-model="settings.battlesHidePvE" label="Hide PvE"/>
+                <Checkbox v-model="settings.battlesHideLocked" label="Hide Locked"/>
+                <Checkbox v-model="settings.battlesHideEmpty" label="Hide Empty"/>
+                <Checkbox v-model="settings.battlesHideInProgress" label="Hide Running"/>
+                <SearchBox v-model="searchVal"/>
             </div>
 
             <div class="battlelist">
@@ -116,25 +117,29 @@ import { getFriendlyDuration } from "@/utils/misc";
 import { isSpadsBattle } from "@/utils/type-checkers";
 
 const hostBattleOpen = ref(false);
-const hidePvE = ref(false);
-const hideLocked = ref(false);
-const hideEmpty = ref(true);
 const searchVal = ref("");
 const selectedBattle: Ref<SpadsBattle | null> = shallowRef(null);
 const passwordPromptOpen = ref(false);
 const failureReason: Ref<string | undefined> = ref();
+const settings = api.settings.model;
 const battles = computed(() => {
     let battles = Array.from(api.session.battles.values());
 
     battles = battles.filter((battle) => {
-        if (hidePvE.value && battle.bots.length > 0) {
+        if (settings.battlesHideEmpty && battle.users.length === 0) {
             return false;
         }
-        if (hideLocked.value && (battle.battleOptions.locked || battle.battleOptions.passworded)) {
+        if (settings.battlesHideLocked && (battle.battleOptions.locked || battle.battleOptions.passworded)) {
             return false;
         }
-        if (hideEmpty.value && battle.users.length === 0) {
+        if (settings.battlesHidePvE && battle.bots.length > 0) {
             return false;
+        }
+        const runtime = battle.runtimeMs.value;
+        if (settings.battlesHideInProgress) {
+            if (runtime && Number.isInteger(runtime) && runtime > 0) {
+                return false;
+            }
         }
         if (searchVal.value.length > 0) {
             const searchTerm = searchVal.value.toLowerCase();

--- a/src/renderer/views/multiplayer/custom.vue
+++ b/src/renderer/views/multiplayer/custom.vue
@@ -137,9 +137,24 @@ const battles = computed(() => {
             return false;
         }
         if (searchVal.value.length > 0) {
-            if (!battle.battleOptions.title.toLowerCase().includes(searchVal.value.toLowerCase())) {
-                return false;
+            const searchTerm = searchVal.value.toLowerCase();
+            if (battle.battleOptions.title.toLowerCase().includes(searchTerm)) {
+                return true;
             }
+            if (battle.battleOptions.map.toLowerCase().includes(searchTerm)) {
+                return true;
+            }
+            for (const player of battle.players.value) {
+                if (player.username.toLowerCase().includes(searchTerm)) {
+                    return true;
+                }
+            }
+            for (const spectator of battle.spectators.value) {
+                if (spectator.username.toLowerCase().includes(searchTerm)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         return true;


### PR DESCRIPTION
Resolves https://github.com/beyond-all-reason/bar-lobby/issues/160
Resolves https://github.com/beyond-all-reason/bar-lobby/issues/150
Partially resolves https://github.com/beyond-all-reason/bar-lobby/issues/158

- Search now searches by battle title, map title, player name, spectator name
- Added filter by running (if the game is active)
- All filters now save with other lobby settings

There is no debounce on the search currently, the actual filter time is miniscule on my machine which should be a good indication that it won't be problematic on older machines - however re-rendering the DOM is another matter, I'll make a note to work on a search debounce later.

![electron_SLfxIdCed3](https://user-images.githubusercontent.com/3493638/226503094-df910363-89a1-46b0-adbc-d9bf39db1faa.png)
![electron_mjMpHhsL01](https://user-images.githubusercontent.com/3493638/226754325-c7ccfefd-3d5e-4ed6-861e-68a90232bbb6.png)

