### PR TITLE
Sort custom lobbies based on "best lobby" instead of by players

### DIFF
--- a/src/renderer/utils/misc.ts
+++ b/src/renderer/utils/misc.ts
@@ -1,9 +1,13 @@
 import { intervalToDuration } from "date-fns";
 import fs from "fs";
 
-export function getFriendlyDuration(durationMs: number) {
-    const durtationValues = intervalToDuration({ start: 0, end: durationMs });
-    return `${durtationValues.hours}:${durtationValues.minutes?.toString().padStart(2, "0")}:${durtationValues.seconds?.toString().padStart(2, "0")}`;
+export function getFriendlyDuration(durationMs: number, withSeconds = true) {
+    const durationValues = intervalToDuration({ start: 0, end: durationMs });
+    const result = `${durationValues.hours}:${durationValues.minutes?.toString().padStart(2, "0")}`;
+    if (withSeconds) {
+        return result + `:${durationValues.seconds?.toString().padStart(2, "0")}`;
+    }
+    return result;
 }
 
 export async function isFileInUse(filePath: string): Promise<boolean> {

--- a/src/renderer/views/multiplayer/custom.vue
+++ b/src/renderer/views/multiplayer/custom.vue
@@ -35,14 +35,6 @@
                     @row-select="onRowSelect"
                     @row-dblclick="onDoubleClick"
                 >
-                    <Column headerStyle="width: 0" sortable sortField="isLockedOrPassworded.value">
-                        <template #header>
-                            <Icon :icon="lock" />
-                        </template>
-                        <template #body="{ data }">
-                            <Icon v-if="data.isLockedOrPassworded.value" :icon="lock" />
-                        </template>
-                    </Column>
                     <Column header="Best Battle" sortable sortField="score">
                         <template #body="{ data }">
                             <div class="flex-row flex-center-items gap-md">
@@ -73,6 +65,14 @@
                             <div v-if="data.runtimeMs.value >= 1">
                                 {{ getFriendlyDuration(data.runtimeMs.value) }}
                             </div>
+                        </template>
+                    </Column>
+                    <Column headerStyle="width: 0" sortable sortField="isLockedOrPassworded.value">
+                        <template #header>
+                            <Icon :icon="lock" />
+                        </template>
+                        <template #body="{ data }">
+                            <Icon v-if="data.isLockedOrPassworded.value" :icon="lock" />
                         </template>
                     </Column>
                 </DataTable>
@@ -196,11 +196,11 @@ function scoreBattle(battle: SpadsBattle) {
     }
 
     if (battle.battleOptions.locked) {
-        addFactor("Locked", -5);
+        addFactor("Locked", -9);
     }
 
     if (battle.battleOptions.passworded) {
-        addFactor("Passworded", -5);
+        addFactor("Passworded", -9);
     }
 
     const runtime = battle.runtimeMs.value || 0;

--- a/src/renderer/views/multiplayer/custom.vue
+++ b/src/renderer/views/multiplayer/custom.vue
@@ -231,7 +231,7 @@ function scoreBattle(battle: SpadsBattle) {
 
     const queueSize = battle.battleOptions.joinQueueUserIds?.length || 0;
     if (!running && playerCount >= maxPlayers) {
-        addFactor("Full", 1 - queueSize * 0.5);
+        addFactor("Full", -queueSize * 0.5);
     }
 
     // TODO: within skill range
@@ -244,7 +244,7 @@ function scoreBattle(battle: SpadsBattle) {
     // TODO: Is a noob lobby and I am noob
 
     if (!running && playerCount) {
-        addFactor("Waiting for players", (2 * playerCount) / maxPlayers);
+        addFactor("Waiting for players", (1.2 * playerCount) / maxPlayers);
     }
 
     // Number of spectators


### PR DESCRIPTION
Closes #237 
Fix https://github.com/beyond-all-reason/bar-lobby/issues/223

The first lobby should be the lobby that gives you the best chance of jumping into a game as fast as possible

Adds a "scoreBattle" function to the end of the battles list that will score values based on provided values in the issue list. This also re-orders the columns of the custom battles to place the battle "best status" on the far left side. Scores are adjusted so that running battles, or battles ending soon, will display above locked battles but still show locked battles on the first page, if you have them enabled.

Let me know what you think and if you'd like me to polish further.

Example battle list result:
![image](https://github.com/beyond-all-reason/bar-lobby/assets/1368558/befb5564-191f-4f37-9611-417cfe5b900b)


The battle that you want to join will always be placed at the top. One thing to note is the "ending soon" battles that are full and potentially will be finishing up shortly. Here, we also have a lobby full of spectators and it's placed higher because it might be a bit more renown
