### PR TITLE
need to await downloadComplete

### DIFF
--- a/src/renderer/api/content/engine-content.ts
+++ b/src/renderer/api/content/engine-content.ts
@@ -108,7 +108,7 @@ export class EngineContentAPI extends AbstractContentAPI<EngineVersion> {
         await fs.promises.unlink(downloadFile);
 
         removeFromArray(this.currentDownloads, downloadInfo);
-        this.downloadComplete(downloadInfo);
+        await this.downloadComplete(downloadInfo);
 
         return engineName;
     }


### PR DESCRIPTION
Need to await downloadComplete, since it is async.

This was causing InitialSetup to fail when downloading the game, since `api.content.engine.installedVersions` was empty.