### PR TITLE
Add Friend Info To Battle List

### DIFF
--- a/src/common/model/settings.ts
+++ b/src/common/model/settings.ts
@@ -12,4 +12,5 @@ export const settingsSchema = Type.Object({
     battlesHidePvE: Type.Boolean({ default: false }),
     battlesHideLocked: Type.Boolean({ default: false }),
     battlesHideEmpty: Type.Boolean({ default: true }),
+    battlesHideNoFriends: Type.Boolean({ default: false })
 });

--- a/src/common/model/settings.ts
+++ b/src/common/model/settings.ts
@@ -12,5 +12,5 @@ export const settingsSchema = Type.Object({
     battlesHidePvE: Type.Boolean({ default: false }),
     battlesHideLocked: Type.Boolean({ default: false }),
     battlesHideEmpty: Type.Boolean({ default: true }),
-    battlesHideNoFriends: Type.Boolean({ default: false })
+    battlesHideNoFriends: Type.Boolean({ default: false }),
 });

--- a/src/renderer/views/multiplayer/custom.vue
+++ b/src/renderer/views/multiplayer/custom.vue
@@ -61,7 +61,9 @@
                         <template #body="{ data }">
                             <div class="flex-row flex-center-items gap-md">
                                 <div v-if="data.players.value.length > 0" class="flex-row flex-center-items" style="gap: 2px">
-                                    <Icon :icon="friendsInBattle(data).length > 0 ? accountMultiple : account" height="17" />{{ data.players.value.length }}
+                                    <Icon :icon="friendsInBattle(data).length > 0 ? accountMultiple : account" height="17" />{{
+                                        data.players.value.length
+                                    }}
                                 </div>
                                 <div v-if="data.spectators.value.length > 0" class="flex-row flex-center-items gap-xs" style="gap: 4px">
                                     <Icon :icon="eye" height="17" />{{ data.spectators.value.length }}
@@ -285,7 +287,7 @@ function scoreBattle(battle: SpadsBattle) {
     // TODO: median skill close to won
     const friendsInBattleList = friendsInBattle(battle);
     if (friendsInBattleList.length > 0) {
-        addFactor("Friends In Battle", friendsInBattleList.length * 0.5)
+        addFactor("Friends In Battle", friendsInBattleList.length * 0.5);
     }
     // TODO: blocked in lobby
     // TODO: Highly rated map

--- a/src/renderer/views/multiplayer/custom.vue
+++ b/src/renderer/views/multiplayer/custom.vue
@@ -61,9 +61,11 @@
                         <template #body="{ data }">
                             <div class="flex-row flex-center-items gap-md">
                                 <div v-if="data.players.value.length > 0" class="flex-row flex-center-items" style="gap: 2px">
-                                    <Icon :icon="friendsInBattle(data).length > 0 ? accountMultiple : account" height="17" />{{
-                                        data.players.value.length
-                                    }}
+                                    <Icon
+                                        :color="friendsInBattle(data).length > 0 ? 'green' : ''"
+                                        :icon="friendsInBattle(data).length > 0 ? accountMultiple : account"
+                                        height="17"
+                                    />{{ data.players.value.length }}
                                 </div>
                                 <div v-if="data.spectators.value.length > 0" class="flex-row flex-center-items gap-xs" style="gap: 4px">
                                     <Icon :icon="eye" height="17" />{{ data.spectators.value.length }}


### PR DESCRIPTION
Fixes #140 

Features:
- Friends are shown through a new "multiple account" icon.
- Added a filter to show only battles with friends.
- Battles are scored higher depending on the number of friends.

![image](https://github.com/beyond-all-reason/bar-lobby/assets/64571081/50b70890-3844-4b36-b82f-3eba9be2891b)