### PR TITLE
Fix VSCode debug settings so that can debug main and fix reload on error

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,15 +1,16 @@
 {
     "version": "0.2.0",
     "configurations": [
-    
         {
             "type": "node",
             "request": "launch",
             "name": "Electron: Main",
-            "runtimeExecutable": "npm",
-            "runtimeArgs": [
-                "run", "debug"
-            ]
+            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron-vite",
+            "windows": {
+                "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron-vite.cmd"
+            },
+            "runtimeArgs": ["--sourcemap"],
+            "env": { "REMOTE_DEBUGGING_PORT": "9223" }
         },
         {
             "name": "Electron: Renderer",
@@ -23,10 +24,10 @@
     "compounds": [
         {
             "name": "Electron: All",
-            "configurations": [
-                "Electron: Main",
-                "Electron: Renderer"
-            ]
+            "configurations": ["Electron: Main", "Electron: Renderer"],
+            "presentation": {
+                "order": 1
+            }
         }
     ]
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,7 +61,7 @@ export class Application {
         app.on("web-contents-created", (event, contents) => {
             contents.on("will-navigate", (event, navigationUrl) => {
                 const parsedUrl = new URL(navigationUrl);
-                if (process.env.ELECTRON_RENDERER_URL && parsedUrl.protocol == "http:" && parsedUrl == new URL(process.env.ELECTRON_RENDERER_URL)) {
+                if (process.env.ELECTRON_RENDERER_URL && parsedUrl.protocol == "http:" && parsedUrl.toString() == process.env.ELECTRON_RENDERER_URL + "/") {
                     return; //allow
                 }
                 if (parsedUrl.protocol == "file:" && parsedUrl.pathname) {


### PR DESCRIPTION
Does the title.

Updates the VS code debugging settings so that the electron main process can be debugged.
Updates the Electron main process to fix the "reload" button so that it restarts the Electron application [it used to do this before].