### PR TITLE
Fix crash when opening the game options

### DIFF
--- a/src/renderer/utils/parse-lua-options.ts
+++ b/src/renderer/utils/parse-lua-options.ts
@@ -18,7 +18,7 @@ export function parseLuaOptions(lua: Buffer): LuaOptionSection[] {
         const baseOption: Omit<LuaOption, "type"> = {
             key: luaOptionObj.key,
             name: luaOptionObj.name,
-            description: luaOptionObj.desc.replaceAll("\\n", "\n"),
+            description: luaOptionObj.desc?.replaceAll("\\n", "\n"),
             hidden: luaOptionObj.hidden ?? false,
         };
 
@@ -61,7 +61,7 @@ export function parseLuaOptions(lua: Buffer): LuaOptionSection[] {
                     type: "list",
                     key: option.key,
                     name: option.name,
-                    description: option.desc.replaceAll("\\n", "\n"),
+                    description: option.desc?.replaceAll("\\n", "\n"),
                     hidden: option.hidden,
                 });
             }


### PR DESCRIPTION
This fixes a crash when opening the game options. The issue was due to luaObjectObj.desc sometimes being null.