### PR TITLE
Improve MapCard hover effects

### DIFF
--- a/src/renderer/components/maps/MapOverviewCard.vue
+++ b/src/renderer/components/maps/MapOverviewCard.vue
@@ -63,8 +63,10 @@ const imageUrl = computed(() =>
         }
         .background {
             transform: scale(1.01);
+            transition: 0.2s ease-in-out;
             &:after {
                 opacity: 0;
+                transition: 0.2s ease-in-out;
             }
         }
         .attributes {
@@ -81,16 +83,15 @@ const imageUrl = computed(() =>
     background-position: center;
     position: relative;
     transform: scale(1.1);
-    transition: 0.1s transform;
     will-change: transform;
     z-index: 0;
     &:after {
         @extend .fullsize;
         z-index: 1;
         background: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0));
-        transition: 0.1s opacity;
+        transition: 0.2s opacity ease-in-out;
     }
-    transition: background-image 0.1s ease-in-out;
+    transition: 0.2s ease-in-out;
 }
 .name {
     @extend .fullsize;


### PR DESCRIPTION
Add transition to MapCard background scale and `::after` opacity.

Previously there were two `transition` effects defined for `.background` but the second one not only cancelled out the first one, it also didn't seem to do anything either visually or in code - there are no changes anywhere to background image. So I removed it.