### PR TITLE
Handle incomplete packages (interrupted pr-downloader)

### DIFF
--- a/src/main/content/game/game-content.ts
+++ b/src/main/content/game/game-content.ts
@@ -61,7 +61,13 @@ export class GameContentAPI extends PrDownloaderAPI<string, GameVersion> {
             await this.initLookupTables();
         }
         for (const packageFile of packages) {
-            const packageMd5 = packageFile.replace(".sdp", "");
+            if (!packageFile.endsWith(".sdp")) {
+                // skip non-sdp files
+                // one case is pr-downloader interruption, which makes .sdp.incomplete files
+                log.debug(`Skipping non-sdp file: ${packageFile}!`);
+                continue;
+            }
+            const packageMd5 = packageFile.split(".")[0];
             const gameVersion = this.packageGameVersionLookup[packageMd5];
             const luaOptionSections = await this.getGameOptions(packageMd5);
             const ais = await this.getAis(packageMd5);


### PR DESCRIPTION
Previous behavior could cause lobby to fail to start at all if pr-downloader was interrupted (e.g. lobby ctrl+c)

The current code assumes package files always end with .sdp: 
https://github.com/beyond-all-reason/bar-lobby/blob/51f712e7913456516a4dd80658e1afba1984b750/src/main/content/game/game-content.ts#L64
but in case of interruption the file would end up as `9b005eca52648684723e123af117f44b.sdp.incomplete`.

So the result would be `9b005eca52648684723e123af117f44b.incomplete` which eventually results in file access error when it, down the line, tries to access nonexistent `9b005eca52648684723e123af117f44b.incomplete.sdp`.

Paging author of the code @bcdrme and @p2004a for a good measure 