### PR TITLE
fixup of #202: Hovering on the edge of controls spams their hover event and sound 

### DIFF
--- a/src/renderer/components/battle/OfflineBattleComponent.vue
+++ b/src/renderer/components/battle/OfflineBattleComponent.vue
@@ -17,10 +17,10 @@
                         class="fullwidth"
                         @update:model-value="onMapSelected"
                     />
-                    <Button v-tooltip.left="'Open map selector'" @click="openMapList">
+                    <Button v-tooltip.left="{ value: 'Open map selector', showDelay: 300, hideDelay: 200 }" @click="openMapList">
                         <Icon :icon="listIcon" height="23" />
                     </Button>
-                    <Button v-tooltip.left="'Configure map options'" @click="openMapOptions">
+                    <Button v-tooltip.left="{ value: 'Configure map options', showDelay: 300, hideDelay: 200 }" @click="openMapOptions">
                         <Icon :icon="cogIcon" height="23" />
                     </Button>
                     <MapListModal v-model="mapListOpen" title="Maps" @map-selected="onMapSelected" />

--- a/src/renderer/styles/_tooltip.scss
+++ b/src/renderer/styles/_tooltip.scss
@@ -3,6 +3,9 @@ $color: #222;
 .p-tooltip {
     z-index: 10;
     max-width: 400px;
+    transform: translateY(5px);
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
     &-text {
         background: $color;
         padding: 2px 7px;


### PR DESCRIPTION
- added border to the tooltip so that mouse hover won't trigger event spam anymore 
- tooltips more robust by using a debounce mechanism