### PR TITLE
Fix the engine download race condition

### DIFF
--- a/src/renderer/components/misc/InitialSetup.vue
+++ b/src/renderer/components/misc/InitialSetup.vue
@@ -33,6 +33,7 @@ onMounted(async () => {
         await window.engine.downloadEngine(latestKnownEngineVersion.id);
         text.value = "Installing engine";
     }
+    enginesStore.selectedEngineVersion = latestKnownEngineVersion;
 
     state.value = "game";
     text.value = "Downloading game";

--- a/src/renderer/store/engine.store.ts
+++ b/src/renderer/store/engine.store.ts
@@ -33,8 +33,5 @@ export async function initEnginesStore() {
         enginesStore.selectedEngineVersion = enginesStore.availableEngineVersions.find((e) => e.id === downloadInfo.name);
     });
     await refreshStore();
-    const latestInstalledVersion = enginesStore.availableEngineVersions.filter((e) => e.installed).at(-1);
-    const latestKnownVersion = enginesStore.availableEngineVersions.at(-1);
-    enginesStore.selectedEngineVersion = latestInstalledVersion || latestKnownVersion;
     enginesStore.isInitialized = true;
 }


### PR DESCRIPTION
Fixes #331 by eliminating the race condition.

Root cause identified by @wereii. Thank you for that analysis :)

The solution involves removing the lines that set the `selectedEngineVersion` during the `initEnginesStore` function.

The reason is that setting `selectedEngineVersion` triggers the watch function which then downloads the engine. This isn't needed because `initialSetup` already checks to see if the latest engine is downloaded and downloads it if not.

We can safely remove the direct setting of `selectedEngineVersion` in the function because the function also defines an event that triggers when the engine download is completed to set the selected engine version to the version that was downloaded.

So the flow goes:

1. InitialSetup sees that the engine is not downloaded and downloads it 
2. When download is completed: the selectedEngineVersion is set by the callback.

This retains the intended feature of the "watch" function [which was if the user selects a different engine version in the UI: we download that engine version].