### PR TITLE
Fix errors getting overlaid by other modals

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -43,9 +43,11 @@
             </div>
         </Transition>
         <Settings v-model="settingsOpen" />
-        <Error />
         <ChatComponent v-if="state === 'default' && me.isAuthenticated && tachyonStore.isConnected" />
         <FullscreenGameModeSelector v-if="state === 'default'" :visible="battleStore.isSelectingGameMode" />
+    </div>
+    <div id="error-container">
+        <Error />
     </div>
 </template>
 

--- a/src/renderer/components/common/Modal.vue
+++ b/src/renderer/components/common/Modal.vue
@@ -1,5 +1,5 @@
 <template>
-    <Teleport v-if="isLoaded" to="#wrapper">
+    <Teleport v-if="isLoaded" to="#wrapper" :disabled="isError">
         <form v-if="isOpen" ref="form" class="container" @submit.prevent="onSubmit" @keydown.enter="onSubmit">
             <Panel id="modal" class="modal-panel" v-bind="$attrs">
                 <template #header>
@@ -40,6 +40,7 @@ export type PanelProps = InstanceType<typeof Panel>["$props"];
 export interface ModalProps extends /* @vue-ignore */ PanelProps {
     modelValue?: boolean;
     title?: string;
+    isError?: boolean; // disables teleport - errors have dedicated container
 }
 
 const isLoaded = ref(false);
@@ -52,6 +53,7 @@ const props = withDefaults(defineProps<ModalProps>(), {
     title: undefined,
     is: "div",
     activeTab: 0,
+    isError: false,
 });
 
 const emits = defineEmits<{

--- a/src/renderer/components/misc/Error.vue
+++ b/src/renderer/components/misc/Error.vue
@@ -1,5 +1,5 @@
 <template>
-    <Modal v-model="isVisible" title="Fatal Error" class="error-modal">
+    <Modal v-model="isVisible" title="Fatal Error" class="error-modal" isError>
         <div class="flex-col gap-md">
             <div>A fatal error has occurred and BAR Lobby needs to reload.</div>
             <div v-if="error" class="error">{{ error.message }}</div>


### PR DESCRIPTION
My solution to #344

The problem is that Error is modal too, so they all teleport to same space, specifically get appended to \#wrapper - I don't know why in this specific case the bot selection modal ends up lower in the tree (error should be appended after the click right?) then the Error modal but it does.  
I am of the opinion that Errors should be special modals with their own dedicated place that ensures it renders over anything else, see the solution.

Though I am not that experienced with Vue and frontend work so there is probably a better solution to this. Modals should not care about what they are displaying so the isError is bad, maybe noTeleport or something like that would be better.
