### PR TITLE
Add info about running package before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ npm start
     - **main** and **preload** are directly bundled to `.vite/build`
 - `npm run package`
     - Runs `electron-forge` in `production` mode
-    - **renderer** us bundled to `.vite/renderer`
+    - **renderer** is bundled to `.vite/renderer`
     - **main** and **preload** are bundled to `.vite/build`
+    - This should be run before any of the `npm run build` commands below.
 - `npm run preview`
     - Runs `electron-forge` in `production` mode, and runs electron
     - **main**, **preload**, and **renderer** are bundled to `.vite/build`


### PR DESCRIPTION
Adds additional information to the readme that explains you should run `npm run package` before running the `npm run build` commands.