### PR TITLE
Default engine version logic

### DIFF
--- a/src/main/config/default-versions.ts
+++ b/src/main/config/default-versions.ts
@@ -8,4 +8,4 @@
 
 export const LATEST = "LATEST";
 export const LATEST_GAME_VERSION = "byar:test";
-export const LATEST_ENGINE_VERSION = "2025.01.6";
+export const DEFAULT_ENGINE_VERSION = "2025.01.6";

--- a/src/main/content/engine/engine-content.ts
+++ b/src/main/content/engine/engine-content.ts
@@ -13,7 +13,7 @@ import { getEngineReleaseInfo } from "@main/config/content-sources";
 import { AbstractContentAPI } from "@main/content/abstract-content";
 import { CONTENT_PATH } from "@main/config/app";
 import { DownloadEngine } from "@main/content/game/type";
-import { LATEST_ENGINE_VERSION } from "@main/config/default-versions";
+import { DEFAULT_ENGINE_VERSION } from "@main/config/default-versions";
 
 const log = logger("engine-content.ts");
 
@@ -51,19 +51,14 @@ export class EngineContentAPI extends AbstractContentAPI<string, EngineVersion> 
         return this.availableVersions.get(id)?.installed ?? false;
     }
 
-    public getLatestInstalledVersion() {
-        return this.availableVersions
-            .values()
-            .filter((version) => version.installed)
-            .toArray()
-            .sort((a, b) => a.id.localeCompare(b.id))
-            .at(-1);
+    public getDefaultEngine() {
+        return this.availableVersions.get(DEFAULT_ENGINE_VERSION);
     }
 
     protected checkIfDefaultIsNew() {
-        if (!this.availableVersions.has(LATEST_ENGINE_VERSION)) {
-            this.availableVersions.set(LATEST_ENGINE_VERSION, {
-                id: LATEST_ENGINE_VERSION,
+        if (!this.availableVersions.has(DEFAULT_ENGINE_VERSION)) {
+            this.availableVersions.set(DEFAULT_ENGINE_VERSION, {
+                id: DEFAULT_ENGINE_VERSION,
                 ais: [],
                 installed: false,
             });

--- a/src/main/content/pr-downloader.ts
+++ b/src/main/content/pr-downloader.ts
@@ -36,10 +36,15 @@ export abstract class PrDownloaderAPI<ID, T> extends AbstractContentAPI<ID, T> {
         return new Promise<DownloadInfo>((resolve, reject) => {
             try {
                 log.debug(`Downloading ${name}...`);
-                const latestEngine = engineContentAPI.getLatestInstalledVersion();
-                if (!latestEngine) throw new Error("No installed engine version.");
+
+                const defaultEngine = engineContentAPI.getDefaultEngine();
+
+                // These two errors should in theory never happen...
+                if (!defaultEngine) throw new Error("No default engine version.");
+                if (defaultEngine.installed === false) throw new Error("Default engine is not installed.");
+
                 const binaryName = process.platform === "win32" ? "pr-downloader.exe" : "pr-downloader";
-                const prBinaryPath = path.join(CONTENT_PATH, "engine", latestEngine.id, binaryName);
+                const prBinaryPath = path.join(CONTENT_PATH, "engine", defaultEngine.id, binaryName);
                 const downloadArg = type === "game" ? "--download-game" : "--download-map";
                 const prdProcess = spawn(`${prBinaryPath}`, ["--filesystem-writepath", CONTENT_PATH, downloadArg, name], {
                     env: {

--- a/src/renderer/components/battle/AddBotModal.vue
+++ b/src/renderer/components/battle/AddBotModal.vue
@@ -2,7 +2,7 @@
     <Modal title="Add Bot">
         <div class="flex-col gap-md container">
             <Button
-                v-for="(ai, i) in enginesStore.selectedEngineVersion?.ais"
+                v-for="(ai, i) in enginesStore.getEngineVersion()?.ais"
                 :key="i"
                 v-tooltip.bottom="{ value: ai.description }"
                 class="ai-button"

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -78,7 +78,7 @@ function duplicateBot() {
 
 async function configureBot() {
     botOptions.value =
-        [...(enginesStore.selectedEngineVersion?.ais || []), ...(gameStore.selectedGameVersion?.ais || [])].find(
+        [...(enginesStore.getEngineVersion()?.ais || []), ...(gameStore.selectedGameVersion?.ais || [])].find(
             (ai) => ai.name === props.bot.name
         )?.options || [];
     botOptionsOpen.value = true;

--- a/src/renderer/components/battle/OfflineBattleComponent.vue
+++ b/src/renderer/components/battle/OfflineBattleComponent.vue
@@ -41,8 +41,8 @@
                 </div>
                 <div v-if="settingsStore.devMode">
                     <Select
-                        :modelValue="enginesStore.selectedEngineVersion"
-                        @update:model-value="(engine) => (enginesStore.selectedEngineVersion = engine)"
+                        :modelValue="enginesStore.getEngineVersion()"
+                        @update:model-value="(engine) => enginesStore.setEngineVersion(engine)"
                         :options="enginesStore.availableEngineVersions"
                         data-key="id"
                         optionLabel="id"

--- a/src/renderer/components/misc/DebugSidebar.vue
+++ b/src/renderer/components/misc/DebugSidebar.vue
@@ -34,14 +34,14 @@
         />
 
         <Select
-            :modelValue="enginesStore.selectedEngineVersion"
+            :modelValue="enginesStore.getEngineVersion()"
             :options="enginesStore.availableEngineVersions"
             data-key="id"
             option-label="id"
             label="Engine"
             :filter="true"
             class="fullwidth"
-            @update:model-value="(engine) => (enginesStore.selectedEngineVersion = engine)"
+            @update:model-value="(engine) => enginesStore.setEngineVersion(engine)"
         />
 
         <SyncDataDirsDialog v-model="syncLobbyContentToolOpen" />

--- a/src/renderer/components/misc/InitialSetup.vue
+++ b/src/renderer/components/misc/InitialSetup.vue
@@ -8,7 +8,7 @@
 
 <script lang="ts" setup>
 import { defaultMaps } from "@main/config/default-maps";
-import { LATEST_GAME_VERSION } from "@main/config/default-versions";
+import { DEFAULT_ENGINE_VERSION, LATEST_GAME_VERSION } from "@main/config/default-versions";
 import { DownloadInfo } from "@main/content/downloads";
 import { initBattleStore } from "@renderer/store/battle.store";
 import { db } from "@renderer/store/db";
@@ -26,14 +26,14 @@ const state = ref<"engine" | "game" | "maps">("engine");
 
 onMounted(async () => {
     console.debug("Initial setup");
-    const latestKnownEngineVersion = enginesStore.availableEngineVersions.at(-1);
-    if (latestKnownEngineVersion?.installed === false) {
+    const defaultEngineVersion = enginesStore.availableEngineVersions.find((e) => e.id === DEFAULT_ENGINE_VERSION);
+    if (defaultEngineVersion?.installed === false) {
         state.value = "engine";
         text.value = "Downloading engine";
-        await window.engine.downloadEngine(latestKnownEngineVersion.id);
+        await window.engine.downloadEngine(defaultEngineVersion.id);
         text.value = "Installing engine";
     }
-    enginesStore.selectedEngineVersion = latestKnownEngineVersion;
+    enginesStore.defaultEngineVersion = defaultEngineVersion;
 
     state.value = "game";
     text.value = "Downloading game";

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -231,7 +231,7 @@ function defaultOfflineBattle(engine?: EngineVersion, game?: GameVersion, map?: 
         title: "Offline Custom Battle",
         isOnline: false,
         battleOptions: {
-            engineVersion: engine?.id || enginesStore.selectedEngineVersion?.id,
+            engineVersion: engine?.id || enginesStore.getEngineVersion()?.id,
             gameVersion: game?.gameVersion || gameStore.selectedGameVersion?.gameVersion,
             gameMode: {
                 label: "Classic",
@@ -329,7 +329,8 @@ watch(
 
 watch(
     () => enginesStore.selectedEngineVersion,
-    (engineVersion) => {
+    () => {
+        const engineVersion = enginesStore.getEngineVersion();
         if (!engineVersion) throw new Error("failed to access engine version");
 
         battleStore.battleOptions.engineVersion = engineVersion.id;
@@ -352,9 +353,10 @@ function leaveBattle() {
 
 async function loadGameMode(gameMode: GameModeType) {
     if (!battleStore.battleOptions.engineVersion) {
-        if (!enginesStore.selectedEngineVersion) throw new Error("failed to access engine version");
+        const engineVersion = enginesStore.getEngineVersion();
+        if (!engineVersion) throw new Error("failed to access engine version");
 
-        battleStore.battleOptions.engineVersion = enginesStore.selectedEngineVersion.id;
+        battleStore.battleOptions.engineVersion = engineVersion.id;
     }
     if (!battleStore.battleOptions.gameVersion) {
         if (!gameStore.selectedGameVersion) throw new Error("failed to access game version");

--- a/src/renderer/store/tachyon.store.ts
+++ b/src/renderer/store/tachyon.store.ts
@@ -44,7 +44,8 @@ export async function initTachyonStore() {
 
     window.tachyon.onBattleStart((springString) => {
         console.debug("Received battle start event", springString);
-        if (!enginesStore.selectedEngineVersion) {
+        const engineVersion = enginesStore.getEngineVersion();
+        if (engineVersion === undefined) {
             console.error("No engine version selected");
             return;
         }
@@ -53,7 +54,7 @@ export async function initTachyonStore() {
             return;
         }
         window.game.launchMultiplayer({
-            engineVersion: enginesStore.selectedEngineVersion.id,
+            engineVersion: engineVersion.id,
             gameVersion: gameStore.selectedGameVersion.gameVersion,
             springString,
         });

--- a/src/renderer/views/library/maps/[id].vue
+++ b/src/renderer/views/library/maps/[id].vue
@@ -58,7 +58,7 @@ const { id } = defineProps<{
 const map = useDexieLiveQueryWithDeps([() => id], () => db.maps.get(id));
 
 async function play() {
-    battleActions.resetToDefaultBattle(enginesStore.selectedEngineVersion, gameStore.selectedGameVersion, map.value);
+    battleActions.resetToDefaultBattle(enginesStore.getEngineVersion(), gameStore.selectedGameVersion, map.value);
     router.push("/singleplayer/custom");
 }
 


### PR DESCRIPTION
Fixes #349.

Refactors the engine store concept and enforces the "default engine version" [the hard-coded engine version]. Also: downloading an engine does not set the selected engine version to that downloaded engine version.