### PR TITLE
Fixed Scenario launching crash

### DIFF
--- a/src/main/services/game.service.ts
+++ b/src/main/services/game.service.ts
@@ -20,7 +20,7 @@ function registerIpcHandlers(mainWindow: Electron.BrowserWindow) {
 
     // Game
     ipcMain.handle("game:launchMultiplayer", (_, settings: MultiplayerLaunchSettings) => gameAPI.launchMultiplayer(settings));
-    ipcMain.handle("game:launchScript", (_, settings: ScriptLaunchSettings) => gameAPI.launchScript(settings));
+    ipcMain.handle("game:launchScript", (_, scriptString: string, gameVersionString: string, engineVersionString: string) => gameAPI.launchScript({script:scriptString, engineVersion:engineVersionString, gameVersion:gameVersionString }));
     ipcMain.handle("game:launchReplay", (_, replay: Replay) => gameAPI.launchReplay(replay));
     ipcMain.handle("game:launchBattle", (_, battle: BattleWithMetadata) => gameAPI.launchBattle(battle));
 

--- a/src/main/services/game.service.ts
+++ b/src/main/services/game.service.ts
@@ -1,5 +1,5 @@
 import { gameContentAPI } from "@main/content/game/game-content";
-import { gameAPI, MultiplayerLaunchSettings, ScriptLaunchSettings } from "@main/game/game";
+import { gameAPI, MultiplayerLaunchSettings } from "@main/game/game";
 import { ipcMain } from "electron";
 import { Replay } from "@main/content/replays/replay";
 import { BattleWithMetadata } from "@main/game/battle/battle-types";
@@ -20,7 +20,9 @@ function registerIpcHandlers(mainWindow: Electron.BrowserWindow) {
 
     // Game
     ipcMain.handle("game:launchMultiplayer", (_, settings: MultiplayerLaunchSettings) => gameAPI.launchMultiplayer(settings));
-    ipcMain.handle("game:launchScript", (_, scriptString: string, gameVersionString: string, engineVersionString: string) => gameAPI.launchScript({script:scriptString, engineVersion:engineVersionString, gameVersion:gameVersionString }));
+    ipcMain.handle("game:launchScript", (_, scriptString: string, gameVersionString: string, engineVersionString: string) =>
+        gameAPI.launchScript({ script: scriptString, engineVersion: engineVersionString, gameVersion: gameVersionString })
+    );
     ipcMain.handle("game:launchReplay", (_, replay: Replay) => gameAPI.launchReplay(replay));
     ipcMain.handle("game:launchBattle", (_, battle: BattleWithMetadata) => gameAPI.launchBattle(battle));
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -101,7 +101,7 @@ const gameApi = {
 
     // Game
     launchMultiplayer: (settings: MultiplayerLaunchSettings): Promise<void> => ipcRenderer.invoke("game:launchMultiplayer", settings),
-    launchScript: (script: string): Promise<void> => ipcRenderer.invoke("game:launchScript", script),
+    launchScript: (script: string, gameVersion: string, engineVersion: string): Promise<void> => ipcRenderer.invoke("game:launchScript", script, gameVersion, engineVersion),
     launchReplay: ((replay) => ipcRenderer.invoke("game:launchReplay", replay)) as LaunchReplay,
     launchBattle: (battle: BattleWithMetadata): Promise<void> => ipcRenderer.invoke("game:launchBattle", battle),
 

--- a/src/renderer/views/debug/script-launcher.vue
+++ b/src/renderer/views/debug/script-launcher.vue
@@ -14,7 +14,7 @@ import { ref } from "vue";
 
 import Button from "@renderer/components/controls/Button.vue";
 import Textarea from "@renderer/components/controls/Textarea.vue";
-import { LATEST_GAME_VERSION } from "@main/config/default-versions";
+import { DEFAULT_ENGINE_VERSION, LATEST_GAME_VERSION } from "@main/config/default-versions";
 
 const script = ref(`[game] {
     [ais] {
@@ -37,6 +37,6 @@ const script = ref(`[game] {
 }`);
 
 function launch() {
-    window.game.launchScript(script.value);
+    window.game.launchScript(script.value, LATEST_GAME_VERSION, DEFAULT_ENGINE_VERSION);
 }
 </script>

--- a/src/renderer/views/singleplayer/scenarios.vue
+++ b/src/renderer/views/singleplayer/scenarios.vue
@@ -66,7 +66,7 @@ import Button from "@renderer/components/controls/Button.vue";
 import Select from "@renderer/components/controls/Select.vue";
 import ScenarioTile from "@renderer/components/misc/ScenarioTile.vue";
 import { Scenario } from "@main/content/game/scenario";
-import { LATEST_GAME_VERSION } from "@main/config/default-versions";
+import { LATEST_GAME_VERSION, DEFAULT_ENGINE_VERSION } from "@main/config/default-versions";
 import Panel from "@renderer/components/common/Panel.vue";
 import { db } from "@renderer/store/db";
 import { useDexieLiveQueryWithDeps } from "@renderer/composables/useDexieLiveQuery";
@@ -127,7 +127,7 @@ async function launch() {
         .replaceAll("__RESTRICTEDUNITS__", restrictionsStr)
         .replaceAll("__NUMRESTRICTIONS__", restrictionCount.toString());
 
-    await window.game.launchScript(script);
+    await window.game.launchScript(script, LATEST_GAME_VERSION, DEFAULT_ENGINE_VERSION);
 }
 </script>
 


### PR DESCRIPTION
Render process was passing a `script: string` into IPC, but main was expecting a `settings: ScriptLaunchSettings` instead. This led to crashes when trying to access properties of an undefined object.

The typecheck, format, and lint scripts have been run.