### PR TITLE
Fix janky text wrap in game mode selector

### DIFF
--- a/src/renderer/components/misc/GameModeSelector.vue
+++ b/src/renderer/components/misc/GameModeSelector.vue
@@ -112,7 +112,7 @@ defineEmits(["selected"]);
     font-family: Rajdhani;
     font-weight: bold;
     font-size: 2rem;
-    padding: 20px 40px;
+    padding: 20px calc(50% - 122px);
     color: #fff;
     background: linear-gradient(90deg, #22c55e, #16a34a);
     border: none;


### PR DESCRIPTION
When hovering over each game mode the text in the green box at the bottom of each mode changes it's wrapping during the animation between 1 and 2 lines as demonstrated here:

https://imgur.com/a/Rk7RNli

The cause of the issue is that we change `flex: 1.5` on hover causing the width of each column to change causing a re-layout.
Looking in the inspector you can see the width of the text box changes from 245px to 353px

Not hovering:
![image](https://github.com/user-attachments/assets/b550fafa-f613-478f-9ca0-05658630d5d7)


Hovering:
![image](https://github.com/user-attachments/assets/51169b7e-2b38-4eb4-b692-e172a42a79ee)


We can fix the issue by making the horizontal padding a function of the width, that way as the width increases the padding will also increase but leave the width of the text the same. I've picked a number that gives us the same look as we have now with 40px of horizontal padding in the non hovered state and the width for the text stays locked at 244px

Non hovering:
![image](https://github.com/user-attachments/assets/01894885-08a9-4343-9a68-8899de5f5343)

Hovering:
![image](https://github.com/user-attachments/assets/dac104f3-9295-48fa-ba0a-3b65a568ffe0)

Video demonstration of the fix:
https://imgur.com/a/nuJmM2u
