### PR TITLE
Launch replay with non-live maps

### DIFF
--- a/src/main/content/maps/map-content.ts
+++ b/src/main/content/maps/map-content.ts
@@ -125,12 +125,6 @@ export class MapContentAPI extends PrDownloaderAPI<string, MapData> {
         throw new Error("Method not implemented.");
     }
 
-    public async scanFolderForMaps() {
-        let mapFiles = await fs.promises.readdir(this.mapsDir);
-        mapFiles = mapFiles.filter((mapFile) => mapFile.endsWith("sd7"));
-        return mapFiles;
-    }
-
     public async uninstallVersion(version: MapData) {
         const mapFile = path.join(this.mapsDir, version.filename);
         await fs.promises.rm(mapFile, { force: true, recursive: true });

--- a/src/main/content/maps/map-content.ts
+++ b/src/main/content/maps/map-content.ts
@@ -87,11 +87,10 @@ export class MapContentAPI extends PrDownloaderAPI<string, MapData> {
                 const pathBaseName = path.basename(filepath);
 
                 if (pathBaseName) {
-                    if (this.fileNameMapNameLookup[pathBaseName]) this.mapNameFileNameLookup[this.fileNameMapNameLookup[pathBaseName]] = undefined;
                     const springName = this.fileNameMapNameLookup[pathBaseName];
                     this.fileNameMapNameLookup[pathBaseName] = undefined;
-
                     if (springName) {
+                        this.mapNameFileNameLookup[springName] = undefined;
                         this.onMapDeleted.dispatch(springName);
                     }
                 }

--- a/src/main/content/maps/map-data.ts
+++ b/src/main/content/maps/map-data.ts
@@ -1,10 +1,15 @@
 import { MapMetadata } from "@main/content/maps/map-metadata";
 
-export type MapData = MapMetadata & {
-    imagesBlob?: {
-        preview?: Blob;
+export type MapData = MapMetadata &
+    MapDownloadData & {
+        imagesBlob?: {
+            preview?: Blob;
+        };
+        isFavorite?: boolean;
     };
+
+export type MapDownloadData = {
+    springName: string;
     isInstalled?: boolean;
     isDownloading?: boolean;
-    isFavorite?: boolean;
 };

--- a/src/main/services/maps.service.ts
+++ b/src/main/services/maps.service.ts
@@ -21,13 +21,11 @@ async function fetchAllMaps(): Promise<[MapData[], MapDownloadData[]]> {
         } satisfies MapData;
     });
 
+    const liveMapsSet = new Set(liveMaps.map((m) => m.springName));
+
     const nonLiveMaps = Object.entries(mapContentAPI.mapNameFileNameLookup)
         .map(([springName]) => {
-            if (
-                liveMaps.some((m) => {
-                    return m.springName === springName;
-                })
-            ) {
+            if (liveMapsSet.has(springName)) {
                 return;
             }
 

--- a/src/main/services/maps.service.ts
+++ b/src/main/services/maps.service.ts
@@ -18,7 +18,7 @@ async function fetchAllMaps(): Promise<[MapData[], MapDownloadData[]]> {
         return {
             ...map,
             isInstalled: mapContentAPI.isVersionInstalled(map.springName),
-        };
+        } satisfies MapData;
     });
 
     const nonLiveMaps = (await mapContentAPI.scanFolderForMaps())
@@ -37,7 +37,7 @@ async function fetchAllMaps(): Promise<[MapData[], MapDownloadData[]]> {
                 springName: springName,
                 isDownloading: false,
                 isInstalled: mapContentAPI.isVersionInstalled(springName),
-            } as MapDownloadData;
+            } satisfies MapDownloadData;
         })
         .filter((v) => v != undefined);
 

--- a/src/main/services/maps.service.ts
+++ b/src/main/services/maps.service.ts
@@ -21,10 +21,8 @@ async function fetchAllMaps(): Promise<[MapData[], MapDownloadData[]]> {
         } satisfies MapData;
     });
 
-    const nonLiveMaps = (await mapContentAPI.scanFolderForMaps())
-        .map((filename) => {
-            const springName = mapContentAPI.fileNameMapNameLookup[filename];
-            if (springName == undefined) return;
+    const nonLiveMaps = Object.entries(mapContentAPI.mapNameFileNameLookup)
+        .map(([springName]) => {
             if (
                 liveMaps.some((m) => {
                     return m.springName === springName;

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -5,7 +5,7 @@ import type { GameVersion } from "@main/content/game/game-version";
 import type { Info } from "@main/services/info.service";
 import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent, IpcRenderer, IpcRendererEvent, WebContents } from "electron";
 import type { logLevels } from "@main/services/log.service";
-import type { MapData } from "@main/content/maps/map-data";
+import type { MapData, MapDownloadData } from "@main/content/maps/map-data";
 import type { MultiplayerLaunchSettings } from "@main/game/game";
 import type { NewsFeedData } from "@main/services/news.service";
 import type { Replay } from "@main/content/replays/replay";
@@ -73,7 +73,7 @@ export type IPCCommands = {
     "maps:downloadMaps": (springNames: string[]) => void[];
     "maps:getInstalledVersions": () => Map<string, MapData>;
     "maps:isVersionInstalled": (springName: string) => boolean;
-    "maps:online:fetchAllMaps": () => MapData[];
+    "maps:online:fetchAllMaps": () => [MapData[], MapDownloadData[]];
     "maps:online:fetchMapImages": (imageSource: string) => ArrayBuffer;
     "misc:getDevlogRssFeed": (numberOfNews: number) => NewsFeedData | null | undefined;
     "misc:getNewsRssFeed": (numberOfNews: number) => NewsFeedData | null | undefined;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -4,7 +4,7 @@ import { Replay } from "@main/content/replays/replay";
 import { Settings } from "@main/services/settings.service";
 import { EngineVersion } from "@main/content/engine/engine-version";
 import { GameVersion } from "@main/content/game/game-version";
-import { MapData } from "@main/content/maps/map-data";
+import { MapData, MapDownloadData } from "@main/content/maps/map-data";
 import { DownloadInfo } from "@main/content/downloads";
 import { Info } from "@main/services/info.service";
 import { BattleWithMetadata } from "@main/game/battle/battle-types";
@@ -118,7 +118,7 @@ const mapsApi = {
     isVersionInstalled: (springName: string): Promise<boolean> => ipcRenderer.invoke("maps:isVersionInstalled", springName),
 
     // Online features
-    fetchAllMaps: (): Promise<MapData[]> => ipcRenderer.invoke("maps:online:fetchAllMaps"),
+    fetchAllMaps: (): Promise<[MapData[], MapDownloadData[]]> => ipcRenderer.invoke("maps:online:fetchAllMaps"),
     fetchMapImages: (imageSource: string): Promise<ArrayBuffer | undefined> => ipcRenderer.invoke("maps:online:fetchMapImages", imageSource),
 
     // Events

--- a/src/renderer/components/controls/DownloadContentButton.vue
+++ b/src/renderer/components/controls/DownloadContentButton.vue
@@ -13,13 +13,13 @@
 </template>
 
 <script lang="ts" setup>
-import { MapData } from "@main/content/maps/map-data";
+import { MapDownloadData } from "@main/content/maps/map-data";
 import Button from "@renderer/components/controls/Button.vue";
 import { downloadMap } from "@renderer/store/maps.store";
 import { ButtonProps } from "primevue/button";
 
 export interface Props extends /* @vue-ignore */ ButtonProps {
-    map: MapData;
+    map: MapDownloadData;
     disabled?: boolean;
     class?: string;
     onClick?: (event: MouseEvent) => void;

--- a/src/renderer/store/db.ts
+++ b/src/renderer/store/db.ts
@@ -1,5 +1,5 @@
 import { GameVersion } from "@main/content/game/game-version";
-import { MapData } from "@main/content/maps/map-data";
+import { MapData, MapDownloadData } from "@main/content/maps/map-data";
 import { Replay } from "@main/content/replays/replay";
 import { User } from "@main/model/user";
 import Dexie, { EntityTable } from "dexie";
@@ -12,6 +12,7 @@ export async function initDb() {
 export const db = new Dexie("BarLobby") as Dexie & {
     replays: EntityTable<Replay, "fileName">;
     maps: EntityTable<MapData, "springName">;
+    nonLiveMaps: EntityTable<MapDownloadData, "springName">;
     gameVersions: EntityTable<GameVersion, "gameVersion">;
     users: EntityTable<User, "userId">;
 };
@@ -58,6 +59,11 @@ db.version(1).stores({
         isInstalled,
         isDownloading,
         isFavorite
+    `,
+    nonLiveMaps: `
+        springName,
+        isInstalled,
+        isDownloading
     `,
     gameVersions: "gameVersion, packageMd5",
     users: "userId, username, countryCode, status, displayName, clanId, partyId, scopes, isMe",

--- a/src/renderer/store/maps.store.ts
+++ b/src/renderer/store/maps.store.ts
@@ -106,6 +106,14 @@ export async function downloadMap(springName: string) {
 
     if (!mapIsLive) {
         dbDelegate = db.nonLiveMaps;
+        const isInNonLiveDB = await db.nonLiveMaps.get(springName);
+        if (!isInNonLiveDB) {
+            db.nonLiveMaps.put({
+                springName: springName,
+                isDownloading: false,
+                isInstalled: false,
+            } satisfies MapDownloadData);
+        }
     }
 
     dbDelegate.update(springName, { isDownloading: true });

--- a/src/renderer/store/maps.store.ts
+++ b/src/renderer/store/maps.store.ts
@@ -51,8 +51,7 @@ async function init() {
 
     const [liveMaps, nonLiveMaps] = await window.maps.fetchAllMaps();
 
-    console.debug("Received all live maps", liveMaps);
-    console.debug("Received all nonlive maps", nonLiveMaps);
+    console.debug("Received maps", [liveMaps, nonLiveMaps]);
 
     await Promise.allSettled(
         liveMaps.map((map) => {

--- a/src/renderer/store/maps.store.ts
+++ b/src/renderer/store/maps.store.ts
@@ -54,28 +54,28 @@ async function init() {
     console.debug("Received maps", [liveMaps, nonLiveMaps]);
 
     await Promise.allSettled(
-        liveMaps.map((map) => {
-            db.maps.get(map.springName).then((existingMap) => {
-                if (!existingMap) {
-                    return db.maps.put(map) as Promise<unknown>;
-                } else {
-                    //TODO this has a limitation. if a field change from defined to undefined it will not be updated.
-                    return db.maps.update(map.springName, { ...map, isDownloading: false }) as Promise<unknown>;
-                }
-            });
-        })
-    );
-
-    await Promise.allSettled(
-        nonLiveMaps.map((map) => {
-            db.nonLiveMaps.get(map.springName).then((existingMap) => {
-                if (!existingMap) {
-                    return db.nonLiveMaps.put(map) as Promise<unknown>;
-                } else {
-                    return db.nonLiveMaps.update(map.springName, { ...map }) as Promise<unknown>;
-                }
-            });
-        })
+        liveMaps
+            .map((map) => {
+                db.maps.get(map.springName).then((existingMap) => {
+                    if (!existingMap) {
+                        return db.maps.put(map) as Promise<unknown>;
+                    } else {
+                        //TODO this has a limitation. if a field change from defined to undefined it will not be updated.
+                        return db.maps.update(map.springName, { ...map, isDownloading: false }) as Promise<unknown>;
+                    }
+                });
+            })
+            .concat(
+                nonLiveMaps.map((map) => {
+                    db.nonLiveMaps.get(map.springName).then((existingMap) => {
+                        if (!existingMap) {
+                            return db.nonLiveMaps.put(map) as Promise<unknown>;
+                        } else {
+                            return db.nonLiveMaps.update(map.springName, { ...map, isDownloading: false }) as Promise<unknown>;
+                        }
+                    });
+                })
+            )
     );
 
     mapsStore.isInitialized = true;

--- a/src/renderer/store/maps.store.ts
+++ b/src/renderer/store/maps.store.ts
@@ -78,6 +78,15 @@ async function init() {
             )
     );
 
+    // Refresh the nonLiveMaps
+    const nonLiveMapSet = new Set(nonLiveMaps.map((map) => map.springName));
+
+    (await db.nonLiveMaps.toArray())
+        .filter((map) => !nonLiveMapSet.has(map.springName))
+        .forEach((map) => {
+            db.nonLiveMaps.update(map.springName, { ...map, isInstalled: false });
+        });
+
     mapsStore.isInitialized = true;
 }
 

--- a/src/renderer/views/library/replays.vue
+++ b/src/renderer/views/library/replays.vue
@@ -126,6 +126,7 @@ import { useDexieLiveQueryWithDeps } from "@renderer/composables/useDexieLiveQue
 import ReplayPreview from "@renderer/components/battle/ReplayPreview.vue";
 import DownloadContentButton from "@renderer/components/controls/DownloadContentButton.vue";
 import { gameStore } from "@renderer/store/game.store";
+import { MapDownloadData } from "@main/content/maps/map-data";
 
 const endedNormally: Ref<boolean | null> = ref(true);
 const showSpoilers = ref(true);
@@ -154,9 +155,13 @@ const replays = useDexieLiveQueryWithDeps([endedNormally, offset, limit, sortFie
     return query.reverse().sortBy(sortField.value);
 });
 
-const map = useDexieLiveQueryWithDeps([() => selectedReplay.value?.mapSpringName], () => {
-    if (!selectedReplay.value) return;
-    return db.maps.get(selectedReplay.value.mapSpringName);
+let map = useDexieLiveQueryWithDeps([() => selectedReplay.value?.mapSpringName], async () => {
+    let selected = selectedReplay.value;
+    if (!selected) return;
+
+    let selectedMap = (await db.maps.get(selected.mapSpringName)) as MapDownloadData | undefined;
+
+    return selectedMap ?? db.nonLiveMaps.get(selected.mapSpringName);
 });
 
 function onPage(event: DataTablePageEvent) {

--- a/src/renderer/views/library/replays.vue
+++ b/src/renderer/views/library/replays.vue
@@ -126,7 +126,6 @@ import { useDexieLiveQueryWithDeps } from "@renderer/composables/useDexieLiveQue
 import ReplayPreview from "@renderer/components/battle/ReplayPreview.vue";
 import DownloadContentButton from "@renderer/components/controls/DownloadContentButton.vue";
 import { gameStore } from "@renderer/store/game.store";
-import { MapDownloadData } from "@main/content/maps/map-data";
 
 const endedNormally: Ref<boolean | null> = ref(true);
 const showSpoilers = ref(true);
@@ -159,9 +158,9 @@ let map = useDexieLiveQueryWithDeps([() => selectedReplay.value?.mapSpringName],
     let selected = selectedReplay.value;
     if (!selected) return;
 
-    let selectedMap = (await db.maps.get(selected.mapSpringName)) as MapDownloadData | undefined;
+    const [live, nonLive] = await Promise.all([db.maps.get(selected.mapSpringName), db.nonLiveMaps.get(selected.mapSpringName)]);
 
-    return selectedMap ?? db.nonLiveMaps.get(selected.mapSpringName);
+    return live ?? nonLive;
 });
 
 function onPage(event: DataTablePageEvent) {

--- a/src/renderer/views/library/replays.vue
+++ b/src/renderer/views/library/replays.vue
@@ -126,6 +126,7 @@ import { useDexieLiveQueryWithDeps } from "@renderer/composables/useDexieLiveQue
 import ReplayPreview from "@renderer/components/battle/ReplayPreview.vue";
 import DownloadContentButton from "@renderer/components/controls/DownloadContentButton.vue";
 import { gameStore } from "@renderer/store/game.store";
+import { MapDownloadData } from "@main/content/maps/map-data";
 
 const endedNormally: Ref<boolean | null> = ref(true);
 const showSpoilers = ref(true);
@@ -160,7 +161,17 @@ let map = useDexieLiveQueryWithDeps([() => selectedReplay.value?.mapSpringName],
 
     const [live, nonLive] = await Promise.all([db.maps.get(selected.mapSpringName), db.nonLiveMaps.get(selected.mapSpringName)]);
 
-    return live ?? nonLive;
+    let map = live ?? nonLive;
+
+    if (!map) {
+        map = {
+            springName: selected.mapSpringName,
+            isDownloading: false,
+            isInstalled: false,
+        } satisfies MapDownloadData;
+    }
+
+    return map;
 });
 
 function onPage(event: DataTablePageEvent) {


### PR DESCRIPTION
Fixes #348 by supporting tracking of download progress and install status of "non-live" maps and updating the UI to allow launching replays for non-live maps.

Launching games with non-live maps is not supported by these changes.

This also fixes a pre-existing bug I found when downloading a map, deleting said map, then redownloading the map again. The lobby would never download the map until you restarted the lobby because the system never removed the map from `currentDownloads` array