### PR TITLE
Add team controls in battle options by reflecting starting box changes to team changes.

### DIFF
--- a/src/main/game/battle/battle-types.ts
+++ b/src/main/game/battle/battle-types.ts
@@ -7,7 +7,7 @@ export interface Battle {
     isOnline: boolean;
     battleOptions: BattleOptions;
     me?: Player;
-    teams: Array<Array<Player | Bot>>;
+    teams: Array<Team>;
     spectators: Player[];
     started: boolean;
 }
@@ -129,6 +129,12 @@ export type Bot = {
     advantage?: number;
     incomeMultiplier?: number;
     color?: string;
+};
+
+export type Team = {
+    id: number;
+    maxParticipants: number;
+    participants: Array<Player | Bot>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/main/utils/start-script-converter.ts
+++ b/src/main/utils/start-script-converter.ts
@@ -84,7 +84,7 @@ class StartScriptConverter {
                 }
             }
 
-            team.forEach((teamMember) => {
+            team.participants.forEach((teamMember) => {
                 const { id, advantage, handicap, incomeMultiplier, startPos } = teamMember;
                 const team: Team = {
                     id,

--- a/src/renderer/components/battle/MapOptionsModal.vue
+++ b/src/renderer/components/battle/MapOptionsModal.vue
@@ -86,7 +86,7 @@ import { Ref, ref, watch, computed } from "vue";
 import Modal from "@renderer/components/common/Modal.vue";
 import Button from "@renderer/components/controls/Button.vue";
 import Range from "@renderer/components/controls/Range.vue";
-import { battleStore } from "@renderer/store/battle.store";
+import { battleStore, battleActions } from "@renderer/store/battle.store";
 import { StartBoxOrientation, StartPosType } from "@main/game/battle/battle-types";
 import MapBattlePreview from "@renderer/components/maps/MapBattlePreview.vue";
 import { getBoxes } from "@renderer/utils/start-boxes";
@@ -137,6 +137,8 @@ function addCustomBox() {
         if (lastBox == undefined) return;
         battleStore.battleOptions.mapOptions.customStartBoxes = [...customBoxes, lastBox];
     }
+
+    if (battleStore.teams.length < customBoxes.length + 1) battleActions.addTeam();
 }
 
 function deleteCustomBox(boxId: number) {
@@ -148,6 +150,8 @@ function deleteCustomBox(boxId: number) {
         const newBoxes = customBoxes.filter((_, index) => index !== boxId);
         battleStore.battleOptions.mapOptions.customStartBoxes = newBoxes;
     }
+
+    battleActions.removeTeam(boxId);
 }
 
 function setFixedPositions(index: number) {

--- a/src/renderer/components/battle/TeamComponent.vue
+++ b/src/renderer/components/battle/TeamComponent.vue
@@ -47,7 +47,7 @@ import BotParticipant from "@renderer/components/battle/BotParticipant.vue";
 import PlayerParticipant from "@renderer/components/battle/PlayerParticipant.vue";
 import Button from "@renderer/components/controls/Button.vue";
 import { Bot, isBot, isPlayer, isRaptor, isScavenger, Player, StartPosType } from "@main/game/battle/battle-types";
-import { battleWithMetadataStore } from "@renderer/store/battle.store";
+import { battleActions, battleWithMetadataStore } from "@renderer/store/battle.store";
 
 const props = defineProps<{
     teamId: number;
@@ -60,15 +60,7 @@ const memberCount = computed(() => {
 
 const maxPlayersPerTeam = computed(() => {
     if (!battleWithMetadataStore.battleOptions.map) return 1;
-    if (battleWithMetadataStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes)
-        return battleWithMetadataStore.battleOptions.map.startboxesSet[
-            battleWithMetadataStore.battleOptions.mapOptions.startBoxesIndex || 0
-        ]?.maxPlayersPerStartbox;
-    if (battleWithMetadataStore.battleOptions.mapOptions.startPosType in [StartPosType.Fixed, StartPosType.Random])
-        return battleWithMetadataStore.battleOptions.map.startPos?.team?.[
-            battleWithMetadataStore.battleOptions.mapOptions.fixedPositionsIndex ?? 0
-        ].playersPerTeam;
-    return 1;
+    return battleActions.getMaxPlayersPerTeam();
 });
 
 function isRaptorTeam(teamId: number) {

--- a/src/renderer/components/battle/TeamComponent.vue
+++ b/src/renderer/components/battle/TeamComponent.vue
@@ -22,7 +22,7 @@
             <!-- <Button v-if="showJoin" class="slim black" @click="onJoinClicked(teamId)">Join</Button> -->
         </div>
         <div
-            v-for="member in battleWithMetadataStore.teams[teamId]"
+            v-for="member in battleWithMetadataStore.teams[teamId].participants"
             :key="member.id"
             :draggable="!isRaptorTeam(teamId) && !isScavengerTeam(teamId)"
             @dragstart="onDragStart($event, member)"
@@ -55,7 +55,7 @@ const props = defineProps<{
 const title = isScavengerTeam(props.teamId) ? "Scavengers" : isRaptorTeam(props.teamId) ? "Raptors" : "Team " + (Number(props.teamId) + 1);
 
 const memberCount = computed(() => {
-    return battleWithMetadataStore.teams[props.teamId]?.length || 0;
+    return battleWithMetadataStore.teams[props.teamId]?.participants.length || 0;
 });
 
 const maxPlayersPerTeam = computed(() => {
@@ -72,10 +72,10 @@ const maxPlayersPerTeam = computed(() => {
 });
 
 function isRaptorTeam(teamId: number) {
-    return battleWithMetadataStore.teams[teamId].some((member) => isBot(member) && isRaptor(member));
+    return battleWithMetadataStore.teams[teamId].participants.some((member) => isBot(member) && isRaptor(member));
 }
 function isScavengerTeam(teamId: number) {
-    return battleWithMetadataStore.teams[teamId].some((member) => isBot(member) && isScavenger(member));
+    return battleWithMetadataStore.teams[teamId]?.participants.some((member) => isBot(member) && isScavenger(member));
 }
 
 function getAmountOfJoinButtons(maxPlayersPerTeam: number | undefined, memberCount: number) {

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -54,7 +54,7 @@ watch(
     battleStore,
     (battle) => {
         Object.assign(_battleWithMetadataStore, battle);
-        _battleWithMetadataStore.participants = battle.teams.flatMap(team => team.participants);
+        _battleWithMetadataStore.participants = battle.teams.flatMap((team) => team.participants);
         _battleWithMetadataStore.bots = _battleWithMetadataStore.participants.filter((participant) => "aiShortName" in participant);
         _battleWithMetadataStore.players = _battleWithMetadataStore.participants.filter((participant) => "user" in participant);
         if (battle.started && !_battleWithMetadataStore.startTime) _battleWithMetadataStore.startTime = new Date();
@@ -75,7 +75,6 @@ function removeFromSpectators(participant: Player) {
 }
 
 function removeTeam(teamId: number) {
-
     if (!battleStore.teams[teamId]) {
         console.error(`Trying to remove team with teamId=${teamId}`, "Teams:", battleStore.teams);
         return;
@@ -83,7 +82,7 @@ function removeTeam(teamId: number) {
 
     const teamParticipants = battleStore.teams[teamId].participants;
 
-    teamParticipants.map((participant) => isPlayer(participant) ? movePlayerToSpectators(participant as Player) : removeBot(participant));
+    teamParticipants.map((participant) => (isPlayer(participant) ? movePlayerToSpectators(participant as Player) : removeBot(participant)));
 
     battleStore.teams.splice(teamId, 1);
 }
@@ -110,7 +109,7 @@ function addTeam() {
     }
 
     const newTeams = [...battleStore.teams];
-    
+
     // Find the index where this team should go or replace
     const existingIndex = newTeams.findIndex((team) => team.id === newTeamId);
 
@@ -125,12 +124,12 @@ function addTeam() {
     // Sort teams by ID for consistency
     newTeams.sort((a, b) => a.id - b.id);
 
-    newTeams.forEach(team => team.maxParticipants = maxParticipants / newTeams.length)
+    newTeams.forEach((team) => (team.maxParticipants = maxParticipants / newTeams.length));
 
     // Update the teams array
     battleStore.teams = newTeams;
 
-    console.log(battleStore.teams)
+    console.log(battleStore.teams);
 
     return newTeamId;
 }
@@ -255,7 +254,7 @@ function updateTeams() {
     const maxPlayersPerTeam = getMaxPlayersPerTeam();
 
     console.log("numberOfTeams:", numberOfTeams, "maxPlayersPerTeam:", maxPlayersPerTeam, "battleStore.teams.length:", battleStore.teams.length);
-    
+
     // Try to keep players on the same team, then fill the other teams, then move extra players to spectators
 
     // Adjust number of teams
@@ -269,12 +268,10 @@ function updateTeams() {
         }
     }
 
-    battleStore.teams = battleStore.teams.map(team => {
+    battleStore.teams = battleStore.teams.map((team) => {
         team.maxParticipants = maxPlayersPerTeam;
         return team;
     });
-
-
 
     // Remove extra players/bots from teams
     // for (const [index, team] of battleStore.teams.entries()) {
@@ -360,7 +357,6 @@ function defaultOfflineBattle(engine?: EngineVersion, game?: GameVersion, map?: 
         name: "AI 1",
         aiShortName: barbAi?.shortName || "BARb",
     } satisfies Bot;
-
 
     battle.teams[1].participants.push(defaultBot);
 


### PR DESCRIPTION
### Added
- New `Team` interface in battle-types.
- New functions for adding and removing teams.

### Changed
- Changed the structure for teams from an array of players/bots to the interface `Team`.
- Refactored code managing team state to use new functions and interface.
