### PR TITLE
Use dedicated component for Error instead of Modal

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -44,10 +44,10 @@
         </Transition>
         <Settings v-model="settingsOpen" />
         <ServerSettings v-model="serverSettingsOpen" />
-        <Error />
         <ChatComponent v-if="state === 'default' && me.isAuthenticated && tachyonStore.isConnected" />
         <FullscreenGameModeSelector v-if="state === 'default'" :visible="battleStore.isSelectingGameMode" />
     </div>
+    <Error />
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
Simpplifies the Error component a little bit and makes sure it's rendered always on top of the window. Additional changes:
- Add "Quit to desktop" button
- Removes "Close" button: force user to reload/restart
- Improves the state/error reporting for log upload, and replace potentially unreliable tooltip that uses teleport with div.

Fixes #344