### PR TITLE
Fix username display and terrain icon layout issues

### DIFF
--- a/src/renderer/components/maps/MapOverviewCard.vue
+++ b/src/renderer/components/maps/MapOverviewCard.vue
@@ -140,6 +140,9 @@ const imageUrl = computed(() =>
     &.br {
         bottom: 10px;
         right: 10px;
+        flex-wrap: wrap-reverse;
+        justify-content: flex-end;
+        max-width:55%;
     }
 }
 </style>

--- a/src/renderer/store/me.store.ts
+++ b/src/renderer/store/me.store.ts
@@ -49,9 +49,15 @@ async function changeAccount() {
     me.isAuthenticated = false;
 }
 
+window.tachyon.onEvent("user/self", (event) => {
+    // console.log(`Received user/self event: ${JSON.stringify(event)}`);
+    if(event && event.user){
+        Object.assign(me, event.user);
+    }
+});
+
 window.tachyon.onEvent("user/updated", (event) => {
     console.log(`Received user/updated event: ${JSON.stringify(event)}`);
-
     // TODO change this when we have a proper protocol for users
     // see https://github.com/beyond-all-reason/tachyon/blob/master/docs/schema/user.md
     const myData = event.users[0];


### PR DESCRIPTION
# Changes

- Added CSS rules so terrain icons create another row instead of overlapping

Fixes #399

![Screenshot 2025-06-09 181856](https://github.com/user-attachments/assets/4452c513-9a3d-4129-a098-dbba87008467)

- Added an event handler for `user/self` that populates `me` with relevant data

Fixes #391

> **Note:** The data doesn't persist with UI refreshes, but this should be a dev-only issue.