### PR TITLE
Map download progress added to Library > Map/Replay

### DIFF
--- a/src/renderer/views/library/maps/[id].vue
+++ b/src/renderer/views/library/maps/[id].vue
@@ -68,9 +68,14 @@
                                 <Button v-else-if="map.isDownloading" class="green inline" disabled>Downloading map...</Button>
                                 <Button v-else class="red inline" @click="downloadMap(map.springName)">Download</Button>
                             </div>
-							<div class="padding-top-md padding-bottom-md">
-								<Progress :class="{ pulse: isDownloading }" :percent="downloadPercent" v-if="isDownloading" :text="(downloadPercent * 100).toFixed(0) + '%'"></Progress>
-							</div>
+                            <div class="padding-top-md padding-bottom-md">
+                                <Progress
+                                    :class="{ pulse: isDownloading }"
+                                    :percent="downloadPercent"
+                                    v-if="isDownloading"
+                                    :text="(downloadPercent * 100).toFixed(0) + '%'"
+                                ></Progress>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -110,8 +115,7 @@ import waves from "@iconify-icons/mdi/waves";
 import gridIcon from "@iconify-icons/mdi/grid";
 import windPower from "@iconify-icons/mdi/wind-power";
 import { downloadsStore } from "@renderer/store/downloads.store";
-import { ref, computed } from "vue";
-
+import { computed } from "vue";
 
 const router = useRouter();
 const { id } = defineProps<{

--- a/src/renderer/views/library/maps/[id].vue
+++ b/src/renderer/views/library/maps/[id].vue
@@ -68,6 +68,9 @@
                                 <Button v-else-if="map.isDownloading" class="green inline" disabled>Downloading map...</Button>
                                 <Button v-else class="red inline" @click="downloadMap(map.springName)">Download</Button>
                             </div>
+							<div class="padding-top-md padding-bottom-md">
+								<Progress :class="{ pulse: isDownloading }" :percent="downloadPercent" v-if="isDownloading" :text="(downloadPercent * 100).toFixed(0) + '%'"></Progress>
+							</div>
                         </div>
                     </div>
                 </div>
@@ -95,6 +98,7 @@ import { gameStore } from "@renderer/store/game.store";
 import { downloadMap } from "@renderer/store/maps.store";
 import { useDexieLiveQueryWithDeps } from "@renderer/composables/useDexieLiveQuery";
 import Panel from "@renderer/components/common/Panel.vue";
+import Progress from "@renderer/components/common/Progress.vue";
 import MapSimplePreview from "@renderer/components/maps/MapSimplePreview.vue";
 import TerrainIcon from "@renderer/components/maps/filters/TerrainIcon.vue";
 import { Icon } from "@iconify/vue";
@@ -105,6 +109,9 @@ import personIcon from "@iconify-icons/mdi/person-multiple";
 import waves from "@iconify-icons/mdi/waves";
 import gridIcon from "@iconify-icons/mdi/grid";
 import windPower from "@iconify-icons/mdi/wind-power";
+import { downloadsStore } from "@renderer/store/downloads.store";
+import { ref, computed } from "vue";
+
 
 const router = useRouter();
 const { id } = defineProps<{
@@ -126,6 +133,19 @@ function toggleMapFavorite() {
 function returnToMaps() {
     router.push("/library/maps/maps");
 }
+
+const isDownloading = computed(() => downloadsStore.mapDownloads.length > 0);
+
+const downloadPercent = computed(() => {
+    const downloads = downloadsStore.mapDownloads;
+    let currentBytes = 0;
+    let totalBytes = 0;
+    for (const download of downloads) {
+        currentBytes += download.currentBytes;
+        totalBytes += download.totalBytes;
+    }
+    return currentBytes / totalBytes || 0;
+});
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
This adds a small progress bar that appears when a map is being downloaded from either the Library > Replays or Library > Maps > [id] views. The progress bar appears below the buttons, and then disappears when complete. It displays the progress as both a horizontal progress bar as well as a two-digit number with percentage sign after (e.g. "50%").

Lint, Typecheck, and Format have been run.

Fixes https://github.com/beyond-all-reason/bar-lobby/issues/350