### PR TITLE
Fetch and display dynamic matchmaking queues (#392)

### DIFF
--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -26,11 +26,8 @@
             "ranked": {
                 "title": "Ranked",
                 "description": "Join a multiplayer ranked queue.",
-                "modes": {
-                    "2v2": "2 vs 2",
-                    "1v1": "DUEL",
-                    "3v3": "3 vs 3"
-                },
+                "loadingQueues": "Loading matchmaking queues...",
+                "queueError": "Error loading queues",
                 "buttons": {
                     "searchGame": "Search game",
                     "searchingForOpponent": "Searching for opponent",

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2009,11 +2009,8 @@
             "ranked": {
                 "title": null,
                 "description": null,
-                "modes": {
-                    "2v2": null,
-                    "1v1": null,
-                    "3v3": null
-                },
+                "loadingQueues": null,
+                "queueError": null,
                 "buttons": {
                     "searchGame": null,
                     "searchingForOpponent": null,

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -1880,11 +1880,8 @@
             "ranked": {
                 "title": null,
                 "description": null,
-                "modes": {
-                    "2v2": null,
-                    "1v1": null,
-                    "3v3": null
-                },
+                "loadingQueues": null,
+                "queueError": null,
                 "buttons": {
                     "searchGame": null,
                     "searchingForOpponent": null,

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -1857,11 +1857,8 @@
             "ranked": {
                 "title": "Ranked",
                 "description": "Join a multiplayer ranked queue.",
-                "modes": {
-                    "2v2": "2 vs 2",
-                    "1v1": "DUEL",
-                    "3v3": "3 vs 3"
-                },
+                "loadingQueues": "Loading matchmaking queues...",
+                "queueError": "Error loading queues",
                 "buttons": {
                     "searchGame": "Search game",
                     "searchingForOpponent": "Searching for opponent",

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -3862,11 +3862,8 @@
             "ranked": {
                 "title": null,
                 "description": null,
-                "modes": {
-                    "2v2": null,
-                    "1v1": null,
-                    "3v3": null
-                },
+                "loadingQueues": null,
+                "queueError": null,
                 "buttons": {
                     "searchGame": null,
                     "searchingForOpponent": null,

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -3831,11 +3831,8 @@
             "ranked": {
                 "title": null,
                 "description": null,
-                "modes": {
-                    "2v2": null,
-                    "1v1": null,
-                    "3v3": null
-                },
+                "loadingQueues": null,
+                "queueError": null,
                 "buttons": {
                     "searchGame": null,
                     "searchingForOpponent": null,

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -3973,11 +3973,8 @@
             "ranked": {
                 "title": null,
                 "description": null,
-                "modes": {
-                    "2v2": null,
-                    "1v1": null,
-                    "3v3": null
-                },
+                "loadingQueues": null,
+                "queueError": null,
                 "buttons": {
                     "searchGame": null,
                     "searchingForOpponent": null,

--- a/src/renderer/store/matchmaking.store.ts
+++ b/src/renderer/store/matchmaking.store.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { reactive } from "vue";
+import { MatchmakingListOkResponseData } from "tachyon-protocol/types";
 
 export enum MatchmakingStatus {
     Idle = "Idle",
@@ -16,14 +17,22 @@ export const matchmakingStore = reactive<{
     isDrawerOpen: boolean;
     status: MatchmakingStatus;
     selectedQueue: string;
+    playlists: MatchmakingListOkResponseData["playlists"];
+    isLoadingQueues: boolean;
+    queueError?: string;
 }>({
     isInitialized: false,
     isDrawerOpen: false,
     status: MatchmakingStatus.Idle,
     selectedQueue: "1v1",
+    playlists: [],
+    isLoadingQueues: false,
+    queueError: undefined,
 });
 
 export function initializeMatchmakingStore() {
+    if (matchmakingStore.isInitialized) return;
+
     window.tachyon.onEvent("matchmaking/queueUpdate", (event) => {
         console.debug(`matchmaking/queueUpdate: ${JSON.stringify(event)}`);
     });
@@ -48,6 +57,42 @@ export function initializeMatchmakingStore() {
     });
 
     matchmakingStore.isInitialized = true;
+}
+
+export function fetchAvailableQueues() {
+    matchmakingStore.isLoadingQueues = true;
+    matchmakingStore.queueError = undefined;
+
+    return window.tachyon
+        .request("matchmaking/list")
+        .then((response) => {
+            if (response.status === "success" && response.data) {
+                const data = response.data as MatchmakingListOkResponseData;
+                matchmakingStore.playlists = data.playlists;
+
+                // Set default selected queue if current selection is not available
+                const hasSelectedQueue = data.playlists.some((playlist) => playlist.id === matchmakingStore.selectedQueue);
+                if (data.playlists.length > 0 && !hasSelectedQueue) {
+                    matchmakingStore.selectedQueue = data.playlists[0].id;
+                }
+            } else {
+                console.error("Failed to fetch available queues", response);
+                const failedResponse = response as any;
+                matchmakingStore.queueError = failedResponse.reason || "Failed to fetch queues";
+            }
+        })
+        .catch((error) => {
+            console.error("Error fetching available queues:", error);
+            matchmakingStore.queueError = "Network error";
+        })
+        .finally(() => {
+            matchmakingStore.isLoadingQueues = false;
+        });
+}
+
+export function getPlaylistName(id: string): string {
+    const playlist = matchmakingStore.playlists.find((playlist) => playlist.id === id);
+    return playlist?.name || id;
 }
 
 export const matchmaking = {

--- a/src/renderer/store/matchmaking.store.ts
+++ b/src/renderer/store/matchmaking.store.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { reactive } from "vue";
-import { MatchmakingListOkResponseData } from "tachyon-protocol/types";
+import { MatchmakingListOkResponseData, MatchmakingListFailResponse } from "tachyon-protocol/types";
 
 export enum MatchmakingStatus {
     Idle = "Idle",
@@ -77,7 +77,7 @@ export function fetchAvailableQueues() {
                 }
             } else {
                 console.error("Failed to fetch available queues", response);
-                const failedResponse = response as any;
+                const failedResponse = response as MatchmakingListFailResponse;
                 matchmakingStore.queueError = failedResponse.reason || "Failed to fetch queues";
             }
         })

--- a/src/renderer/store/tachyon.store.ts
+++ b/src/renderer/store/tachyon.store.ts
@@ -7,6 +7,7 @@ import { gameStore } from "@renderer/store/game.store";
 import { auth, me } from "@renderer/store/me.store";
 import { SystemServerStatsOkResponseData } from "tachyon-protocol/types";
 import { reactive } from "vue";
+import { fetchAvailableQueues } from "@renderer/store/matchmaking.store";
 
 export const tachyonStore = reactive({
     isInitialized: false,
@@ -71,6 +72,9 @@ export async function initTachyonStore() {
         }
         // Periodically fetch server stats
         tachyonStore.fetchServerStatsInterval = setInterval(fetchServerStats, 60000);
+
+        // Fetch matchmaking queues when connected
+        fetchAvailableQueues();
     });
 
     window.tachyon.onDisconnected(() => {

--- a/src/renderer/views/multiplayer/ranked.vue
+++ b/src/renderer/views/multiplayer/ranked.vue
@@ -20,32 +20,23 @@ SPDX-License-Identifier: MIT
                 <div></div>
             </div>
             <div class="mode-select">
+                <div v-if="matchmakingStore.isLoadingQueues" class="loading-queues">
+                    {{ t("lobby.multiplayer.ranked.loadingQueues") }}
+                </div>
+                <div v-else-if="matchmakingStore.queueError" class="queue-error">
+                    {{ t("lobby.multiplayer.ranked.queueError") }}: {{ matchmakingStore.queueError }}
+                </div>
                 <Button
+                    v-else
+                    v-for="queue in availableQueueIds"
+                    :key="queue"
                     class="mode-column classic"
                     :class="{
-                        selected: matchmakingStore.selectedQueue === '2v2',
+                        selected: matchmakingStore.selectedQueue === queue,
                     }"
-                    @click="() => (matchmakingStore.selectedQueue = '2v2')"
+                    @click="() => (matchmakingStore.selectedQueue = queue)"
                     :disabled="matchmakingStore.status !== MatchmakingStatus.Idle"
-                    ><span>{{ t("lobby.multiplayer.ranked.modes.2v2") }}</span></Button
-                >
-                <Button
-                    class="mode-column classic"
-                    :class="{
-                        selected: matchmakingStore.selectedQueue === '1v1',
-                    }"
-                    @click="() => (matchmakingStore.selectedQueue = '1v1')"
-                    :disabled="matchmakingStore.status !== MatchmakingStatus.Idle"
-                    ><span>{{ t("lobby.multiplayer.ranked.modes.1v1") }}</span></Button
-                >
-                <Button
-                    class="mode-column classic"
-                    :class="{
-                        selected: matchmakingStore.selectedQueue === '3v3',
-                    }"
-                    @click="() => (matchmakingStore.selectedQueue = '3v3')"
-                    :disabled="matchmakingStore.status !== MatchmakingStatus.Idle"
-                    ><span>{{ t("lobby.multiplayer.ranked.modes.3v3") }}</span></Button
+                    ><span>{{ getPlaylistName(queue) }}</span></Button
                 >
             </div>
             <div class="button-container">
@@ -87,11 +78,16 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script lang="ts" setup>
-import { matchmaking, MatchmakingStatus, matchmakingStore } from "@renderer/store/matchmaking.store";
+import { matchmaking, MatchmakingStatus, matchmakingStore, getPlaylistName } from "@renderer/store/matchmaking.store";
 import Button from "primevue/button";
 import { useTypedI18n } from "@renderer/i18n";
+import { computed } from "vue";
 
 const { t } = useTypedI18n();
+
+const availableQueueIds = computed(() => {
+    return matchmakingStore.playlists.sort((a, b) => a.teamSize * a.numOfTeams - b.teamSize * b.numOfTeams).map((playlist) => playlist.id);
+});
 </script>
 
 <style lang="scss" scoped>
@@ -139,6 +135,22 @@ const { t } = useTypedI18n();
     height: 100%;
     overflow: visible;
     gap: 50px;
+}
+
+.loading-queues,
+.queue-error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 200px;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.2rem;
+    text-align: center;
+}
+
+.queue-error {
+    color: #ff6b6b;
 }
 
 .mode-column {


### PR DESCRIPTION
Added fetchAvailableQueues which retrieves the matchmaking/list data.  This is called in window.tachyon.onConnected.  Maybe there's a better place for this but it seemed appropriate.

ranked.vue displays the dynamic playlist data now, and sorts it by total player count

All of the queues are displayed using the 'classic' background image defined in css currently as it doesn't look like there are specific background images for multiplayer yet.

Closes #392 