### PR TITLE
Quick fix for broken sorting in the MapListComponent

### DIFF
--- a/src/renderer/components/maps/MapListComponent.vue
+++ b/src/renderer/components/maps/MapListComponent.vue
@@ -54,7 +54,7 @@ type SortMethod = { label: string; dbKey: string };
 
 const sortMethods: SortMethod[] = [
     { label: "Name", dbKey: "displayName" },
-    { label: "Size", dbKey: "width" },
+    { label: "Size", dbKey: "mapWidth" },
 ];
 const sortMethod: Ref<SortMethod | undefined> = ref(sortMethods.at(0));
 const searchVal = ref("");


### PR DESCRIPTION
**Fix for #461** 

The `dbkey` field name for the sort methods was incorrect. Causing the query to fail and probably returned some unsorted results. After checking the schema in  `map-metadata.ts`, fixing the fieldname fixed the issue.