### PR TITLE
added a proof-of-concept fix where the game would freeze when clicking on the 'open replays folder' button in the replays section, without a filemanager installed (fix only works for i3)

### DIFF
--- a/src/main/services/shell.service.ts
+++ b/src/main/services/shell.service.ts
@@ -6,9 +6,80 @@ import { STATE_PATH, CONFIG_PATH, WRITE_DATA_PATH, REPLAYS_PATH, ASSETS_PATH } f
 import { shell } from "electron";
 import { ipcMain } from "@main/typed-ipc";
 import path from "path";
+import { execSync, spawn, exec } from 'child_process';
 
 const REPLAY_SERVICE_URL = "https://bar-rts.com/replays";
 const NEWS_SERVICE_URL = "https://www.beyondallreason.info/news";
+
+// Check for file managers in PATH
+function hasFileManager() {
+    const managers = ['nautilus', 'thunar', 'pcmanfm', 'dolphin', 'nemo'];
+    return managers.some(cmd => {
+        try {
+            execSync(`command -v ${cmd}`, { stdio: 'ignore' });
+            return true;
+        } catch {
+            return false;
+        }
+    });
+}
+
+// Detect if running in i3
+function isI3Session() {
+    try {
+        const wm = execSync('wmctrl -m', { encoding: 'utf8' });
+        return wm.toLowerCase().includes('i3');
+    } catch {
+        try {
+            const ps = execSync('ps -e', { encoding: 'utf8' });
+            return ps.toLowerCase().includes('i3');
+        } catch {
+            return false;
+        }
+    }
+}
+
+function focusTerminal() {
+    exec('i3-msg -t get_tree', (err, stdout) => {
+        if (err) {
+            console.error('Failed to get i3 tree:', err);
+            return;
+        }
+        try {
+            const tree = JSON.parse(stdout);
+
+            // Recursive search for window whose title ends with /demos
+            function findWindow(node) {
+                if (node.window && typeof node.name === 'string') {
+                    if (node.name.endsWith('/demos')) {
+                        return node.window; // return window id
+                    }
+                }
+                if (node.nodes) {
+                    for (const child of node.nodes) {
+                        const res = findWindow(child);
+                        if (res) return res;
+                    }
+                }
+                return null;
+            }
+
+            const winId = findWindow(tree);
+            if (!winId) {
+                console.error('No terminal window ending with /demos found');
+                return;
+            }
+
+            // Focus by window ID
+            exec(`i3-msg [id=${winId}] focus`, (error) => {
+                if (error) console.error('Failed to focus window:', error);
+            });
+        } catch (e) {
+            console.error('Failed to parse i3 tree JSON:', e);
+        }
+    });
+}
+
 
 // Careful with shell.openExternal. https://benjamin-altpeter.de/shell-openexternal-dangers/
 function openInBrowser(url: string) {
@@ -24,7 +95,43 @@ function registerIpcHandlers() {
     ipcMain.handle("shell:openAssetsDir", () => shell.openPath(ASSETS_PATH));
     ipcMain.handle("shell:openSettingsFile", () => shell.openPath(path.join(CONFIG_PATH, "settings.json")));
     ipcMain.handle("shell:openStartScript", () => shell.openPath(path.join(WRITE_DATA_PATH, "script.txt")));
-    ipcMain.handle("shell:openReplaysDir", () => shell.openPath(REPLAYS_PATH));
+    ipcMain.handle("shell:openReplaysDir", () => {
+        const inI3 = isI3Session();
+        const hasFM = hasFileManager();
+
+        console.log(inI3);
+        console.log(hasFM);
+
+        if (inI3 && !hasFM) {
+            console.log("i3 without file manager detected — opening in terminal.");
+
+            // Pick your preferred terminal here
+            const terminal = 'alacritty'; // could be 'gnome-terminal', 'kitty', etc.
+
+            // Spawn terminal in detached mode
+            const child = spawn(terminal, ['--working-directory', REPLAYS_PATH], {
+                detached: true,
+                stdio: 'ignore'
+            });
+            child.unref();g
+
+            setTimeout(() => {
+                focusTerminal();
+            }, 1500);
+
+            return REPLAYS_PATH;
+        }
+
+        // Normal case: open using Electron shell (non-blocking)
+        shell.openPath(REPLAYS_PATH)
+            .then(result => {
+                if (result) console.error("Failed to open path:", result);
+            })
+            .catch(err => {
+                console.error("Error opening path:", err);
+            });
+        return REPLAYS_PATH;
+    });
     ipcMain.handle("shell:showReplayInFolder", (_event, fileName: string) => shell.showItemInFolder(path.join(REPLAYS_PATH, fileName)));
 
     // External

--- a/src/main/services/shell.service.ts
+++ b/src/main/services/shell.service.ts
@@ -113,7 +113,7 @@ function registerIpcHandlers() {
                 detached: true,
                 stdio: 'ignore'
             });
-            child.unref();g
+            child.unref();
 
             setTimeout(() => {
                 focusTerminal();


### PR DESCRIPTION
Please describe your changes clearly and concisely. Focus on the "what" and "why" rather than the "how." If your changes are related to an existing issue, please reference it by number (e.g., "Fixes #123").

I've added a functionality to shell:openReplaysDir, where it would check if it is running in I3, and if no filemanager is installed. If so, it will spawn a terminal detached from the bar-lobby application, so that electron won't wait for it to close. 
Additionally I've added 3 functions, to check if it is running in I3, if a filemanager is installed and to focus the terminal into the front, so that it is not stuck behind bar-lobby