### PR TITLE
Fix for missing tokens causing Bad Requests

### DIFF
--- a/src/main/oauth2/oauth2.ts
+++ b/src/main/oauth2/oauth2.ts
@@ -178,7 +178,7 @@ export function startTokenRenewer(interval: number) {
         renewAccessToken().then((value) => {
             accountService.saveRefreshToken(value.refreshToken);
             accountService.saveToken(value.token);
-			log.info("Saved new tokens.");
+            log.info("Saved new tokens.");
         });
     }, interval);
 }

--- a/src/main/oauth2/oauth2.ts
+++ b/src/main/oauth2/oauth2.ts
@@ -174,7 +174,13 @@ export async function renewAccessToken(): Promise<TokenResponse> {
 let tokenRenewer;
 export function startTokenRenewer(interval: number) {
     stopTokenRenewer();
-    tokenRenewer = setInterval(renewAccessToken, interval);
+    tokenRenewer = setInterval(() => {
+        renewAccessToken().then((value) => {
+            accountService.saveRefreshToken(value.refreshToken);
+            accountService.saveToken(value.token);
+			log.info("Saved new tokens.");
+        });
+    }, interval);
 }
 
 export function stopTokenRenewer() {


### PR DESCRIPTION
This PR adds saving Token and Refresh Token to the ``accountService``. This prevents errors cause by bad requests from expired/missing tokens.

Fixes #385 but does not address the commentary regarding the use of URL query parameters, as that is outside of the scope of my experience and skill at this time.

I let this run for more than an hour to ensure there was no errors, and none cropped up where they had before.
Example log:
```
[21:09:06.322] INFO: main - 2025-09-26T01:08:51.424Z - tachyon-client - Connected to wss://lobby-server-dev.beyondallreason.dev/tachyon using Tachyon Version 1.14.1
[21:09:06.322] INFO: main - 2025-09-26T01:08:51.424Z - tachyon-service - Connected to Tachyon server
[21:09:06.323] INFO: main - 2025-09-26T01:08:51.424Z - tachyon-service - Received event: {"data":{"user":{"status":"menu","username":"Hectwo","roles":[],"party":null,"userId":"269","clanId":null,"countryCode":"??","currentLobby":null,"displayName":"Hectwo","friendIds":["271"],"ignoreIds":[],"incomingFriendRequest":[],"invitedToParties":[],"outgoingFriendRequest":[]}},"type":"event","messageId":"6553ac6a-f953-4967-a9b1-e273cb0b1c21","commandId":"user/self"}
[21:24:06.774] INFO: main - 2025-09-26T01:08:51.422Z - oauth2-utils - Saved new tokens.
[21:39:06.782] INFO: main - 2025-09-26T01:08:51.422Z - oauth2-utils - Saved new tokens.
[21:54:06.789] INFO: main - 2025-09-26T01:08:51.422Z - oauth2-utils - Saved new tokens.
[22:09:06.813] INFO: main - 2025-09-26T01:08:51.422Z - oauth2-utils - Saved new tokens.
[22:24:06.798] INFO: main - 2025-09-26T01:08:51.422Z - oauth2-utils - Saved new tokens.
```