### PR TITLE
Resume chat history from the last marker on reconnect

### DIFF
--- a/src/renderer/components/navbar/Messages.vue
+++ b/src/renderer/components/navbar/Messages.vue
@@ -36,10 +36,13 @@ SPDX-License-Identifier: MIT
                         v-model="text"
                         v-in-view="focusTextbox"
                         class="reply"
+                        :disabled="!tachyonStore.isConnected"
                         :placeholder="t('lobby.navbar.messages.message')"
                         @keyup.enter.stop="sendDirectMessage(userId, text)"
                     />
-                    <Button @click="sendDirectMessage(userId, text)">{{ t("lobby.navbar.messages.send") }}</Button>
+                    <Button :disabled="!tachyonStore.isConnected" @click="sendDirectMessage(userId, text)">{{
+                        t("lobby.navbar.messages.send")
+                    }}</Button>
                 </div>
             </TabPanel>
             <TabPanel>
@@ -58,10 +61,13 @@ SPDX-License-Identifier: MIT
                         <Textbox
                             v-model="newMessage"
                             class="reply"
+                            :disabled="!tachyonStore.isConnected"
                             :placeholder="t('lobby.navbar.messages.message')"
                             @keyup.enter.stop="sendDirectMessage(newMessageUserId, newMessage)"
                         />
-                        <Button @click="sendDirectMessage(newMessageUserId, newMessage)">{{ t("lobby.navbar.messages.send") }}</Button>
+                        <Button :disabled="!tachyonStore.isConnected" @click="sendDirectMessage(newMessageUserId, newMessage)">{{
+                            t("lobby.navbar.messages.send")
+                        }}</Button>
                     </div>
                 </div>
             </TabPanel>
@@ -83,6 +89,7 @@ import Markdown from "@renderer/components/misc/Markdown.vue";
 import PopOutPanel from "@renderer/components/navbar/PopOutPanel.vue";
 import { useTypedI18n } from "@renderer/i18n";
 import { chatStore, chat } from "@renderer/store/chat.store";
+import { tachyonStore } from "@renderer/store/tachyon.store";
 import { UserId } from "tachyon-protocol/types";
 import { User } from "@main/model/user";
 import { me } from "@renderer/store/me.store";
@@ -143,6 +150,9 @@ function focusTextbox(el: HTMLElement) {
 }
 
 function sendDirectMessage(destinationUserId: string, messageText: string) {
+    // Button's disabled prop only styles the control, it does not stop the click.
+    if (!tachyonStore.isConnected) return;
+
     chat.requestSend({
         target: {
             type: "player",

--- a/src/renderer/components/party/PartyChat.vue
+++ b/src/renderer/components/party/PartyChat.vue
@@ -26,10 +26,11 @@ SPDX-License-Identifier: MIT
                 v-model="text"
                 v-in-view="focusTextbox"
                 class="reply"
+                :disabled="!tachyonStore.isConnected"
                 :placeholder="t('lobby.navbar.messages.message')"
                 @keyup.enter.stop="sendPartyMessage(text)"
             />
-            <Button @click="sendPartyMessage(text)">{{ t("lobby.navbar.messages.send") }}</Button>
+            <Button :disabled="!tachyonStore.isConnected" @click="sendPartyMessage(text)">{{ t("lobby.navbar.messages.send") }}</Button>
         </div>
     </div>
 </template>
@@ -37,6 +38,7 @@ SPDX-License-Identifier: MIT
 <script lang="ts" setup>
 import { ref } from "vue";
 import { chatStore, chat } from "@renderer/store/chat.store";
+import { tachyonStore } from "@renderer/store/tachyon.store";
 import { useDexieLiveQueryWithDeps } from "@renderer/composables/useDexieLiveQuery";
 import { UserId } from "tachyon-protocol/types";
 import { me } from "@renderer/store/me.store";
@@ -65,6 +67,9 @@ const text = ref("");
 const newMessage = ref("");
 
 function sendPartyMessage(messageText: string) {
+    // Button's disabled prop only styles the control, it does not stop the click.
+    if (!tachyonStore.isConnected) return;
+
     chat.requestSend({
         target: {
             type: "party",

--- a/src/renderer/store/chat.store.ts
+++ b/src/renderer/store/chat.store.ts
@@ -15,6 +15,12 @@ import { onWentOffline } from "@renderer/utils/offline-signal";
 
 const chatSymbol = Symbol("chat.store");
 
+const SUBSCRIBE_RETRY_DELAY = 5000;
+const SUBSCRIBE_ATTEMPT_LIMIT = 5;
+
+let subscribeRetryTimer: ReturnType<typeof setTimeout> | undefined;
+let subscribeAttempts = 0;
+
 export const chatStore: {
     isInitialized: boolean;
     lastMarker: HistoryMarker | null;
@@ -87,16 +93,51 @@ function hasStoredMessages(): boolean {
  * @param data Payload of the data required for this request via Tachyon
  */
 async function requestSubscribeReceived(data?: MessagingSubscribeReceivedRequestData) {
+    subscribeAttempts = 0;
+
+    return subscribeReceived(data);
+}
+
+async function subscribeReceived(data?: MessagingSubscribeReceivedRequestData) {
+    cancelSubscribeRetry();
+    subscribeAttempts++;
+
+    const request = data ?? { since: resumePoint() };
+
     try {
-        const response = await window.tachyon.request("messaging/subscribeReceived", data ?? { since: resumePoint() });
+        const response = await window.tachyon.request("messaging/subscribeReceived", request);
         console.log("Tachyon messaging/subscribeReceived:", response);
-        if (response.data.hasMissedMessages) {
-            console.warn("Tachyon messaging/subscribeReceived: the server could not resume from our marker, history may have gaps");
+        subscribeAttempts = 0;
+
+        // Only a marker we thought was live says anything here. The server also
+        // reports a gap for from_start, where the flag stays set for the rest of
+        // the session once its buffer has overflowed even once.
+        if (response.data.hasMissedMessages && request.since?.type === "marker") {
+            console.warn("Tachyon messaging/subscribeReceived: could not resume from our marker, chat history has a gap");
         }
     } catch (error) {
         console.error("Error with messaging/subscribeReceived", error);
-        notificationsApi.alert({ text: "Error with request messaging/subscribeReceived", severity: "error" });
+        scheduleSubscribeRetry(data);
     }
+}
+
+// A subscription that fails leaves us connected and receiving nothing, with
+// nothing to try again until the socket happens to drop. The server keeps
+// buffering either way, so a later attempt still picks up what was missed.
+function scheduleSubscribeRetry(data?: MessagingSubscribeReceivedRequestData) {
+    if (subscribeAttempts >= SUBSCRIBE_ATTEMPT_LIMIT) {
+        notificationsApi.alert({ text: "Error with request messaging/subscribeReceived", severity: "error" });
+        return;
+    }
+
+    subscribeRetryTimer = setTimeout(() => void subscribeReceived(data), SUBSCRIBE_RETRY_DELAY);
+}
+
+function cancelSubscribeRetry() {
+    if (subscribeRetryTimer === undefined) return;
+
+    clearTimeout(subscribeRetryTimer);
+    subscribeRetryTimer = undefined;
 }
 
 /**
@@ -190,10 +231,15 @@ function addNewUserChat(userId: UserId): boolean {
     } else return false;
 }
 
-// userChats survives; DM history isn't tied to a lobby or party the server just dropped us from.
+// Chat is a transcript of what was said rather than state the server owns, and
+// going offline ends the session holding the only other copy, so none of it can
+// be fetched again. The lobby and party transcripts are cleared on entering the
+// next one instead.
 function clearOnlineState() {
-    clearLobbyChat();
-    clearPartyChat();
+    cancelSubscribeRetry();
+    // system/disconnect stops the session and takes its message buffer with it,
+    // leaving the marker pointing at nothing.
+    chatStore.lastMarker = null;
 }
 
 export const chat = {

--- a/src/renderer/store/chat.store.ts
+++ b/src/renderer/store/chat.store.ts
@@ -4,7 +4,7 @@
 
 import { reactive } from "vue";
 import { subsManager } from "@renderer/store/users.store";
-import { MessagingReceivedEventData, MessagingSendRequestData, MessagingSubscribeReceivedRequestData, UserId } from "tachyon-protocol/types";
+import { HistoryMarker, MessagingReceivedEventData, MessagingSendRequestData, MessagingSubscribeReceivedRequestData, UserId } from "tachyon-protocol/types";
 import { notificationsApi } from "@renderer/api/notifications";
 import { Message } from "@renderer/model/message";
 import { me } from "@renderer/store/me.store";
@@ -17,11 +17,13 @@ const chatSymbol = Symbol("chat.store");
 
 export const chatStore: {
     isInitialized: boolean;
+    lastMarker: HistoryMarker | null;
     lobbyChat: Message[];
     partyChat: Message[];
     userChats: Map<UserId, Message[]>;
 } = reactive({
     isInitialized: false,
+    lastMarker: null,
     lobbyChat: [],
     partyChat: [],
     userChats: new Map<UserId, Message[]>(), // Messages.vue will turn each of these Map elements into a TabPanel for the chat history with that user
@@ -63,13 +65,34 @@ async function requestSend(data: MessagingSendRequestData) {
 }
 
 /**
+ * Works out where the server should resume our message history from.
+ * @returns The `since` value to subscribe with
+ */
+function resumePoint(): MessagingSubscribeReceivedRequestData["since"] {
+    if (chatStore.lastMarker) {
+        return { type: "marker", value: chatStore.lastMarker };
+    }
+
+    // Without a marker there is nothing to line our history up against, so asking
+    // for the whole buffer would repeat anything we already hold.
+    return hasStoredMessages() ? { type: "latest" } : { type: "from_start" };
+}
+
+function hasStoredMessages(): boolean {
+    return chatStore.lobbyChat.length > 0 || chatStore.partyChat.length > 0 || [...chatStore.userChats.values()].some((chat) => chat.length > 0);
+}
+
+/**
  * Send a Tachyon request to subscribe to incoming messages (all types and sources).
  * @param data Payload of the data required for this request via Tachyon
  */
 async function requestSubscribeReceived(data?: MessagingSubscribeReceivedRequestData) {
     try {
-        const response = await window.tachyon.request("messaging/subscribeReceived", data ?? {});
+        const response = await window.tachyon.request("messaging/subscribeReceived", data ?? { since: resumePoint() });
         console.log("Tachyon messaging/subscribeReceived:", response);
+        if (response.data.hasMissedMessages) {
+            console.warn("Tachyon messaging/subscribeReceived: the server could not resume from our marker, history may have gaps");
+        }
     } catch (error) {
         console.error("Error with messaging/subscribeReceived", error);
         notificationsApi.alert({ text: "Error with request messaging/subscribeReceived", severity: "error" });
@@ -83,6 +106,9 @@ async function requestSubscribeReceived(data?: MessagingSubscribeReceivedRequest
  */
 function onMessagingReceivedEvent(data: MessagingReceivedEventData) {
     console.log("Tachyon event: messaging/received:", data);
+    // The server holds one buffer for every source and replays it in order, so
+    // the marker on the message we just got is always the latest one we have.
+    chatStore.lastMarker = data.marker;
     subsManager.attach(data.source.userId, chatSymbol);
     insertMessage(data, data.source);
 }

--- a/src/renderer/store/lobby.store.ts
+++ b/src/renderer/store/lobby.store.ts
@@ -243,9 +243,9 @@ function parseLobbyResponseData(data: LobbyCreateOkResponseData | LobbyJoinOkRes
     } else {
         //Apply the patch for a join/create response
         lobbyStore.activeLobby = applyPatch({}, data);
-        // Messages are not held per lobby, so the previous lobby's chat would
-        // otherwise still be sitting in this one. Reconnecting does not come
-        // through here, which is what keeps a dropped socket from wiping it.
+        // Leaving clears the transcript, but going offline keeps it and sends no
+        // leave, so entering the next lobby has to clear that one. A reconnect
+        // does not come through here, so a dropped socket cannot wipe it.
         chat.clearLobbyChat();
     }
     if (!lobbyStore.activeLobby) {
@@ -314,6 +314,7 @@ async function requestLeaveLobby() {
     // If we ever use a specific view for a lobby instead of BattleDrawer, we need to push a route here
     clearUserSubscriptions();
     lobbyStore.activeLobby = undefined;
+    chat.clearLobbyChat();
 }
 
 /**
@@ -418,6 +419,7 @@ function onLobbyLeftEvent(data: LobbyLeftEventData) {
     if (!lobbyStore.activeLobby || lobbyStore.activeLobby.id != data.id) return;
     clearUserSubscriptions();
     lobbyStore.activeLobby = undefined;
+    chat.clearLobbyChat();
     console.log("Tachyon event: lobby/left:", data);
     if (router.currentRoute.value.path == "/play/lobby") {
         // We use replace instead of push so the user can't use "back".

--- a/src/renderer/store/lobby.store.ts
+++ b/src/renderer/store/lobby.store.ts
@@ -29,6 +29,7 @@ import { notificationsApi } from "@renderer/api/notifications";
 import { Lobby } from "@renderer/model/lobby";
 import { setupI18n } from "@renderer/i18n";
 import { subsManager } from "@renderer/store/users.store";
+import { chat } from "@renderer/store/chat.store";
 import { db } from "@renderer/store/db";
 import { battleStore, battleActions } from "@renderer/store/battle.store";
 import { router } from "@renderer/router";
@@ -242,6 +243,10 @@ function parseLobbyResponseData(data: LobbyCreateOkResponseData | LobbyJoinOkRes
     } else {
         //Apply the patch for a join/create response
         lobbyStore.activeLobby = applyPatch({}, data);
+        // Messages are not held per lobby, so the previous lobby's chat would
+        // otherwise still be sitting in this one. Reconnecting does not come
+        // through here, which is what keeps a dropped socket from wiping it.
+        chat.clearLobbyChat();
     }
     if (!lobbyStore.activeLobby) {
         console.error("Active Lobby is null or undefined after applyPatch. This should never happen!");

--- a/src/renderer/store/party.store.ts
+++ b/src/renderer/store/party.store.ts
@@ -195,6 +195,7 @@ function onUpdatedEvent(data: PartyUpdatedEventData) {
 
 // We might be invited, or member, have to check to know.
 function parseAllPartyData() {
+    const previousParty = partyStore.activeParty;
     // Reset active party in case we are no longer in a party.
     partyStore.activeParty = undefined;
     const bools = {
@@ -216,6 +217,14 @@ function parseAllPartyData() {
         }
     });
     subsManager.setList(users, partySymbol);
+
+    // Messages are not held per party, so a previous party's chat would otherwise
+    // still be sitting in this one. Comparing ids keeps a re-parse of the same
+    // party, which happens on every update, from wiping it.
+    if (partyStore.activeParty && partyStore.activeParty !== previousParty) {
+        chat.clearPartyChat();
+    }
+
     if (bools.joined) {
         if (bools.invited) {
             partyStore.state = PlayersPartyState.JoinedAndInvited;

--- a/src/renderer/store/party.store.ts
+++ b/src/renderer/store/party.store.ts
@@ -218,9 +218,9 @@ function parseAllPartyData() {
     });
     subsManager.setList(users, partySymbol);
 
-    // Messages are not held per party, so a previous party's chat would otherwise
-    // still be sitting in this one. Comparing ids keeps a re-parse of the same
-    // party, which happens on every update, from wiping it.
+    // Leaving clears the transcript, but going offline keeps it and sends no
+    // leave, so entering the next party has to clear that one. Comparing ids keeps
+    // a re-parse of the same party, which happens on every update, from wiping it.
     if (partyStore.activeParty && partyStore.activeParty !== previousParty) {
         chat.clearPartyChat();
     }

--- a/tests/unit/renderer/chat-history-marker.spec.ts
+++ b/tests/unit/renderer/chat-history-marker.spec.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { MessagingReceivedEventData } from "tachyon-protocol/types";
+
+vi.mock("@renderer/api/notifications", () => ({ notificationsApi: { alert: vi.fn() } }));
+
+const receivedHandlers: Array<(data: MessagingReceivedEventData) => void> = [];
+
+Object.assign(window.tachyon, {
+    request: vi.fn(async () => ({ data: { hasMissedMessages: false } })),
+    onEvent: (command: string, callback: (data: MessagingReceivedEventData) => void) => {
+        if (command === "messaging/received") receivedHandlers.push(callback);
+    },
+});
+
+const { chatStore, chat, initChatStore } = await import("@renderer/store/chat.store");
+const { me } = await import("@renderer/store/me.store");
+
+const receive = (data: Partial<MessagingReceivedEventData>) =>
+    receivedHandlers.forEach((handler) =>
+        handler({
+            message: "hi",
+            source: { type: "player", userId: "42" },
+            timestamp: 1_700_000_000_000_000,
+            marker: "-576460745805023",
+            ...data,
+        } as MessagingReceivedEventData)
+    );
+
+const subscribedSince = () => vi.mocked(window.tachyon.request).mock.calls.at(-1)?.[1]?.since;
+
+describe("chat history marker", () => {
+    beforeAll(async () => {
+        await initChatStore();
+    });
+
+    beforeEach(() => {
+        chatStore.lastMarker = null;
+        chatStore.lobbyChat.length = 0;
+        chatStore.partyChat.length = 0;
+        chatStore.userChats.clear();
+        vi.mocked(window.tachyon.request).mockClear();
+    });
+
+    it("keeps the marker off the last message received", async () => {
+        receive({ marker: "-576460745805023" });
+        receive({ marker: "-576460745800000" });
+
+        expect(chatStore.lastMarker).toBe("-576460745800000");
+    });
+
+    // The server buffers every source together, so a marker from a lobby message is
+    // just as valid a resume point for direct messages.
+    it("takes the marker whichever source it came from", async () => {
+        receive({ source: { type: "lobby", lobbyId: "lobby-1", userId: "42" }, marker: "-576460745700000" });
+
+        expect(chatStore.lastMarker).toBe("-576460745700000");
+    });
+
+    // Our own messages never come back from the server, so they carry no marker and
+    // must not become the point we ask to resume from.
+    it("ignores the messages this client sent itself", async () => {
+        receive({ marker: "-576460745805023" });
+        me.userId = "1";
+
+        await chat.requestSend({ target: { type: "player", userId: "42" }, message: "mine" });
+
+        expect(chatStore.lastMarker).toBe("-576460745805023");
+    });
+
+    it("resumes from the marker once it has one", async () => {
+        receive({ marker: "-576460745805023" });
+
+        await chat.requestSubscribeReceived();
+
+        expect(subscribedSince()).toEqual({ type: "marker", value: "-576460745805023" });
+    });
+
+    it("asks for everything the server still holds when it has no marker and no history", async () => {
+        await chat.requestSubscribeReceived();
+
+        expect(subscribedSince()).toEqual({ type: "from_start" });
+    });
+
+    it("asks only for new messages when it has history it cannot place", async () => {
+        chatStore.userChats.set("42", [{ message: "mine" } as never]);
+
+        await chat.requestSubscribeReceived();
+
+        expect(subscribedSince()).toEqual({ type: "latest" });
+    });
+
+    it("lets an explicit request win over the tracked marker", async () => {
+        receive({ marker: "-576460745805023" });
+
+        await chat.requestSubscribeReceived({ since: { type: "latest" } });
+
+        expect(subscribedSince()).toEqual({ type: "latest" });
+    });
+});

--- a/tests/unit/renderer/chat-history-marker.spec.ts
+++ b/tests/unit/renderer/chat-history-marker.spec.ts
@@ -16,6 +16,7 @@ Object.assign(window.tachyon, {
         if (command === "messaging/received") receivedHandlers.push(callback);
     },
 });
+Object.defineProperty(window, "auth", { value: { onChanged: vi.fn() }, writable: true });
 
 const { chatStore, chat, initChatStore } = await import("@renderer/store/chat.store");
 const { me } = await import("@renderer/store/me.store");

--- a/tests/unit/renderer/chat-history-marker.spec.ts
+++ b/tests/unit/renderer/chat-history-marker.spec.ts
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { MessagingReceivedEventData } from "tachyon-protocol/types";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { notificationsApi } from "@renderer/api/notifications";
+import { MessagingReceivedEventData, MessagingSubscribeReceivedRequestData } from "tachyon-protocol/types";
 
 vi.mock("@renderer/api/notifications", () => ({ notificationsApi: { alert: vi.fn() } }));
 
@@ -30,7 +31,13 @@ const receive = (data: Partial<MessagingReceivedEventData>) =>
         } as MessagingReceivedEventData)
     );
 
-const subscribedSince = () => vi.mocked(window.tachyon.request).mock.calls.at(-1)?.[1]?.since;
+const subscribedSince = () => {
+    const [, data] = vi.mocked(window.tachyon.request).mock.calls.at(-1) ?? [];
+
+    return (data as MessagingSubscribeReceivedRequestData | undefined)?.since;
+};
+
+const subscribeCount = () => vi.mocked(window.tachyon.request).mock.calls.filter(([command]) => command === "messaging/subscribeReceived").length;
 
 describe("chat history marker", () => {
     beforeAll(async () => {
@@ -42,7 +49,9 @@ describe("chat history marker", () => {
         chatStore.lobbyChat.length = 0;
         chatStore.partyChat.length = 0;
         chatStore.userChats.clear();
-        vi.mocked(window.tachyon.request).mockClear();
+        vi.mocked(notificationsApi.alert).mockClear();
+        vi.mocked(window.tachyon.request).mockReset();
+        vi.mocked(window.tachyon.request).mockResolvedValue({ data: { hasMissedMessages: false } } as never);
     });
 
     it("keeps the marker off the last message received", async () => {
@@ -93,11 +102,84 @@ describe("chat history marker", () => {
         expect(subscribedSince()).toEqual({ type: "latest" });
     });
 
+    // system/disconnect stops the session GenServer, and it is restart: :temporary,
+    // so the buffer the marker points into is gone for good.
+    it("drops the marker when the user goes offline", async () => {
+        receive({ marker: "-576460745805023" });
+
+        chat.clearOnlineState();
+
+        expect(chatStore.lastMarker).toBeNull();
+    });
+
+    it("does not resume from a marker the server has thrown away", async () => {
+        receive({ marker: "-576460745805023" });
+        chat.clearOnlineState();
+
+        await chat.requestSubscribeReceived();
+
+        expect(subscribedSince()).not.toEqual({ type: "marker", value: "-576460745805023" });
+    });
+
     it("lets an explicit request win over the tracked marker", async () => {
         receive({ marker: "-576460745805023" });
 
         await chat.requestSubscribeReceived({ since: { type: "latest" } });
 
         expect(subscribedSince()).toEqual({ type: "latest" });
+    });
+
+    // A failed subscribe leaves us connected and receiving nothing, and until the
+    // socket happens to drop there is nothing else to try again.
+    describe("when the subscription request fails", () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it("tries again", async () => {
+            vi.mocked(window.tachyon.request).mockRejectedValueOnce(new Error("nope"));
+
+            await chat.requestSubscribeReceived();
+            await vi.advanceTimersByTimeAsync(5000);
+
+            expect(subscribeCount()).toBe(2);
+        });
+
+        it("gives up rather than retrying forever", async () => {
+            vi.mocked(window.tachyon.request).mockRejectedValue(new Error("nope"));
+
+            await chat.requestSubscribeReceived();
+            await vi.advanceTimersByTimeAsync(60_000);
+
+            expect(subscribeCount()).toBe(5);
+            expect(notificationsApi.alert).toHaveBeenCalled();
+        });
+
+        it("stops retrying once the user goes offline", async () => {
+            vi.mocked(window.tachyon.request).mockRejectedValueOnce(new Error("nope"));
+
+            await chat.requestSubscribeReceived();
+            chat.clearOnlineState();
+            await vi.advanceTimersByTimeAsync(60_000);
+
+            expect(subscribeCount()).toBe(1);
+        });
+
+        // Exhausting the retries must not poison the next connection.
+        it("starts counting again on the next connect", async () => {
+            vi.mocked(window.tachyon.request).mockRejectedValue(new Error("nope"));
+            await chat.requestSubscribeReceived();
+            await vi.advanceTimersByTimeAsync(60_000);
+            vi.mocked(window.tachyon.request).mockClear();
+
+            await chat.requestSubscribeReceived();
+            await vi.advanceTimersByTimeAsync(5000);
+
+            expect(subscribeCount()).toBe(2);
+        });
     });
 });

--- a/tests/unit/renderer/chat-history-marker.spec.ts
+++ b/tests/unit/renderer/chat-history-marker.spec.ts
@@ -129,6 +129,38 @@ describe("chat history marker", () => {
         expect(subscribedSince()).toEqual({ type: "latest" });
     });
 
+    // The server splits its buffer at the marker and sends what follows it, so the
+    // round trip has to resume from the last message we actually processed.
+    describe("recovering messages missed while disconnected", () => {
+        it("resumes from the last message it processed and takes the replay", async () => {
+            receive({ source: { type: "player", userId: "42" }, marker: "-576460745805023" });
+
+            // A dropped socket clears nothing, so the marker is still there to resume from.
+            await chat.requestSubscribeReceived();
+
+            expect(subscribedSince()).toEqual({ type: "marker", value: "-576460745805023" });
+
+            receive({ source: { type: "player", userId: "42" }, message: "missed one", marker: "-576460745800000" });
+            receive({ source: { type: "lobby", lobbyId: "lobby-1", userId: "7" }, message: "missed two", marker: "-576460745790000" });
+
+            expect(chatStore.userChats.get("42")?.map((m) => m.message)).toEqual(["hi", "missed one"]);
+            expect(chatStore.lobbyChat.map((m) => m.message)).toEqual(["missed two"]);
+            expect(chatStore.lastMarker).toBe("-576460745790000");
+        });
+
+        // Resuming twice from the same point would re-deliver the replay, so the
+        // marker has to advance as the replayed events are processed.
+        it("leaves the marker at the end of the replay, not the start", async () => {
+            receive({ marker: "-576460745805023" });
+            await chat.requestSubscribeReceived();
+            receive({ marker: "-576460745790000" });
+
+            await chat.requestSubscribeReceived();
+
+            expect(subscribedSince()).toEqual({ type: "marker", value: "-576460745790000" });
+        });
+    });
+
     // A failed subscribe leaves us connected and receiving nothing, and until the
     // socket happens to drop there is nothing else to try again.
     describe("when the subscription request fails", () => {

--- a/tests/unit/renderer/chat-offline-input.spec.ts
+++ b/tests/unit/renderer/chat-offline-input.spec.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import PrimeVue from "primevue/config";
+
+const requestSend = vi.hoisted(() => vi.fn());
+
+vi.mock("@renderer/store/chat.store", () => ({
+    chat: { requestSend, clearUserChat: vi.fn() },
+    chatStore: { partyChat: [], userChats: new Map() },
+}));
+
+vi.mock("@renderer/store/tachyon.store", () => ({ tachyonStore: { isConnected: false } }));
+
+vi.mock("@renderer/composables/useDexieLiveQuery", () => ({
+    useDexieLiveQueryWithDeps: () => ({ value: new Map() }),
+}));
+
+vi.mock("@renderer/store/db", () => ({ db: { users: { each: vi.fn(), filter: () => ({ each: vi.fn() }) } } }));
+
+const { tachyonStore } = await import("@renderer/store/tachyon.store");
+const PartyChat = (await import("@renderer/components/party/PartyChat.vue")).default;
+
+const mountChat = () =>
+    mount(PartyChat, {
+        global: {
+            plugins: [PrimeVue],
+            directives: { "in-view": {} },
+            stubs: { Markdown: true },
+        },
+    });
+
+// Sending while the socket is down used to fail the round trip and raise a
+// generic error, rather than the client declining to offer it.
+describe("chat input while disconnected", () => {
+    beforeEach(() => {
+        requestSend.mockClear();
+    });
+
+    it("disables the input", () => {
+        tachyonStore.isConnected = false;
+
+        const wrapper = mountChat();
+
+        expect(wrapper.find("input").attributes("disabled")).toBeDefined();
+    });
+
+    // Button's disabled prop only adds a class, so the click still lands and the
+    // handler is the only thing standing between it and a doomed request.
+    it("ignores the send button while the socket is down", async () => {
+        tachyonStore.isConnected = false;
+
+        await mountChat().find("button").trigger("click");
+
+        expect(requestSend).not.toHaveBeenCalled();
+    });
+
+    it("sends once connected", async () => {
+        tachyonStore.isConnected = true;
+
+        const wrapper = mountChat();
+        await wrapper.find("input").setValue("hello");
+        await wrapper.find("button").trigger("click");
+
+        expect(requestSend).toHaveBeenCalledWith({ target: { type: "party" }, message: "hello" });
+    });
+});

--- a/tests/unit/renderer/chat-transcript-lifecycle.spec.ts
+++ b/tests/unit/renderer/chat-transcript-lifecycle.spec.ts
@@ -15,6 +15,7 @@ Object.assign(window.tachyon, {
     onDisconnected: vi.fn(),
     onEvent: (command: string, callback: (data: unknown) => void) => void handlers.set(command, callback),
 });
+Object.defineProperty(window, "auth", { value: { onChanged: vi.fn() }, writable: true });
 
 const { chatStore, initChatStore } = await import("@renderer/store/chat.store");
 const { lobby, lobbyStore, initLobbyStore } = await import("@renderer/store/lobby.store");

--- a/tests/unit/renderer/chat-transcript-lifecycle.spec.ts
+++ b/tests/unit/renderer/chat-transcript-lifecycle.spec.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@renderer/router", () => ({ router: { currentRoute: { value: { path: "/" } }, push: vi.fn(), replace: vi.fn() } }));
+vi.mock("@renderer/api/notifications", () => ({ notificationsApi: { alert: vi.fn() } }));
+
+const handlers = new Map<string, (data: unknown) => void>();
+
+Object.assign(window.tachyon, {
+    request: vi.fn(),
+    onConnected: vi.fn(),
+    onDisconnected: vi.fn(),
+    onEvent: (command: string, callback: (data: unknown) => void) => void handlers.set(command, callback),
+});
+
+const { chatStore, initChatStore } = await import("@renderer/store/chat.store");
+const { lobby, lobbyStore, initLobbyStore } = await import("@renderer/store/lobby.store");
+const { partyStore, initPartyStore } = await import("@renderer/store/party.store");
+const { me } = await import("@renderer/store/me.store");
+
+const emit = (command: string, data: unknown) => handlers.get(command)?.(data);
+
+const lobbyPayload = (id: string) => ({ id, players: {}, spectators: {}, bots: {} });
+
+const partyPayload = (id: string) => ({ id, members: [{ userId: me.userId }], invited: [] });
+
+// Neither transcript is held per lobby or party, so entering the next one is what
+// has to clear it. Going offline no longer does, because the server session
+// holding the only other copy ends with it.
+describe("chat transcript lifecycle", () => {
+    beforeAll(async () => {
+        me.userId = "1";
+        await Promise.all([initChatStore(), initLobbyStore(), initPartyStore()]);
+    });
+
+    beforeEach(() => {
+        chatStore.lobbyChat.splice(0, chatStore.lobbyChat.length, { message: "said in the last lobby" } as never);
+        chatStore.partyChat.splice(0, chatStore.partyChat.length, { message: "said in the last party" } as never);
+        lobbyStore.activeLobby = undefined;
+        partyStore.parties.clear();
+        partyStore.activeParty = undefined;
+        vi.mocked(window.tachyon.request).mockReset();
+    });
+
+    describe("lobbies", () => {
+        it("clears the previous lobby's chat on joining another", async () => {
+            vi.mocked(window.tachyon.request).mockResolvedValue({ data: lobbyPayload("lobby-2") } as never);
+
+            await lobby.requestJoinLobby("lobby-2");
+
+            expect(chatStore.lobbyChat).toEqual([]);
+        });
+
+        // A lobby/updated event arrives on any change to the lobby we are already
+        // in, so treating one as an entry would wipe the chat constantly.
+        it("leaves the chat alone on an update to the lobby it is already in", async () => {
+            vi.mocked(window.tachyon.request).mockResolvedValue({ data: lobbyPayload("lobby-2") } as never);
+            await lobby.requestJoinLobby("lobby-2");
+            chatStore.lobbyChat.push({ message: "said in this lobby" } as never);
+
+            emit("lobby/updated", { ...lobbyPayload("lobby-2"), name: "renamed" });
+
+            expect(chatStore.lobbyChat).toHaveLength(1);
+        });
+    });
+
+    describe("parties", () => {
+        it("clears the previous party's chat on joining another", () => {
+            emit("party/updated", partyPayload("party-2"));
+
+            expect(chatStore.partyChat).toEqual([]);
+        });
+
+        it("leaves the chat alone on an update to the party it is already in", () => {
+            emit("party/updated", partyPayload("party-2"));
+            chatStore.partyChat.push({ message: "said in this party" } as never);
+
+            emit("party/updated", partyPayload("party-2"));
+
+            expect(chatStore.partyChat).toHaveLength(1);
+        });
+    });
+});

--- a/tests/unit/renderer/chat-transcript-lifecycle.spec.ts
+++ b/tests/unit/renderer/chat-transcript-lifecycle.spec.ts
@@ -54,6 +54,26 @@ describe("chat transcript lifecycle", () => {
             expect(chatStore.lobbyChat).toEqual([]);
         });
 
+        it("clears the chat on leaving", async () => {
+            vi.mocked(window.tachyon.request).mockResolvedValue({ data: lobbyPayload("lobby-2") } as never);
+            await lobby.requestJoinLobby("lobby-2");
+            chatStore.lobbyChat.push({ message: "said in this lobby" } as never);
+
+            await lobby.requestLeaveLobby();
+
+            expect(chatStore.lobbyChat).toEqual([]);
+        });
+
+        it("clears the chat on being dropped from the lobby", async () => {
+            vi.mocked(window.tachyon.request).mockResolvedValue({ data: lobbyPayload("lobby-2") } as never);
+            await lobby.requestJoinLobby("lobby-2");
+            chatStore.lobbyChat.push({ message: "said in this lobby" } as never);
+
+            emit("lobby/left", { id: "lobby-2" });
+
+            expect(chatStore.lobbyChat).toEqual([]);
+        });
+
         // A lobby/updated event arrives on any change to the lobby we are already
         // in, so treating one as an entry would wipe the chat constantly.
         it("leaves the chat alone on an update to the lobby it is already in", async () => {

--- a/tests/unit/renderer/store-going-offline.spec.ts
+++ b/tests/unit/renderer/store-going-offline.spec.ts
@@ -131,8 +131,24 @@ describe("going offline", () => {
             expect(lobbyStore.lobbies).toEqual({});
             expect(matchmakingStore.status).toBe(MatchmakingStatus.Idle);
             expect(matchmakingStore.playlists).toEqual([]);
-            expect(chatStore.lobbyChat).toEqual([]);
-            expect(chatStore.partyChat).toEqual([]);
+        });
+
+        // Going offline ends the session that held the server's only copy of these
+        // messages, so clearing them here would destroy history nothing can send
+        // again. Entering the next lobby or party is what clears them.
+        it("keeps the chat transcript the server can no longer send us", async () => {
+            await tachyon.goOffline();
+
+            expect(chatStore.lobbyChat).toHaveLength(1);
+            expect(chatStore.partyChat).toHaveLength(1);
+        });
+
+        it("drops the marker, which the ended session leaves pointing at nothing", async () => {
+            chatStore.lastMarker = "-576460745805023";
+
+            await tachyon.goOffline();
+
+            expect(chatStore.lastMarker).toBeNull();
         });
 
         it("keeps what the user picked rather than what the server said", async () => {


### PR DESCRIPTION
Sends the marker from the last message we got when resubscribing, so a reconnect picks up whatever arrived while the socket was down. Fixes #710.

Going offline used to clear the lobby and party transcripts, which is the one case where the server cannot send them again, since system/disconnect stops the session and takes its message buffer with it. They are kept now and cleared on entering or leaving instead. Lobby chat had nothing else clearing it, so it was already carrying over between lobbies. Nothing dedupes the replay, because the marker is always the newest message we hold and the server sends back only what we are missing.

Tested against the dev server with a real socket drop and with a deliberate go offline.

AI disclosure: written with assistance from Claude Code.
